### PR TITLE
Fix incorrectly specified trans header locations for installation.

### DIFF
--- a/src/trans/cpu/CMakeLists.txt
+++ b/src/trans/cpu/CMakeLists.txt
@@ -58,7 +58,7 @@ endforeach()
 
 ## Install trans interface
 
-file( GLOB trans_interface interface/* )
+file( GLOB trans_interface include/ectrans/* )
 install(
   FILES        ${trans_interface}
   DESTINATION  include/ectrans

--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -161,7 +161,7 @@ set_property( TARGET gpu PROPERTY CUDA_ARCHITECTURES 70 )
 
 ## Install trans interface
 
-file( GLOB trans_interface interface/* )
+file( GLOB trans_interface include/ectrans/* )
 install(
   FILES        ${trans_interface}
   DESTINATION  include/ectrans


### PR DESCRIPTION
Trans headers were not getting installed as not searched for in correct location.