### PR TITLE
Discover MPI and propagate OMP for CCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ ecbuild_find_package( NAME fiat REQUIRED )
 
 ecbuild_add_option( FEATURE MPI
                     DESCRIPTION "Support for MPI distributed memory parallelism"
+                    REQUIRED_PACKAGES "MPI COMPONENTS Fortran CXX"
                     CONDITION fiat_HAVE_MPI )
 
 ecbuild_add_option( FEATURE OMP
@@ -103,9 +104,8 @@ if( HAVE_GPU )
 endif()
 
 ecbuild_add_option( FEATURE GPU_AWARE_MPI
-	            DEFAULT OFF
-                    CONDITION HAVE_GPU
-                    REQUIRED_PACKAGES "MPI COMPONENTS CXX Fortran"
+                    DEFAULT OFF
+                    CONDITION HAVE_GPU AND HAVE_MPI
                     DESCRIPTION "Enable CUDA-aware MPI" )
 
 ecbuild_add_option( FEATURE GPU_REDUCED_MEMORY

--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -59,31 +59,32 @@ ectrans_declare_hip_sources( SOURCES_GLOB
 
 foreach( prec dp sp )
   if( HAVE_${prec} )
-	set( GPU_LIBRARY_TYPE SHARED )
-	if( HAVE_GPU_STATIC )
-	    set( GPU_LIBRARY_TYPE STATIC )
+        set( GPU_LIBRARY_TYPE SHARED )
+        if( HAVE_GPU_STATIC )
+            set( GPU_LIBRARY_TYPE STATIC )
         endif()
 
         ectrans_add_library(
-          TARGET           trans_gpu_${prec}
-          TYPE             ${GPU_LIBRARY_TYPE}
-          SOURCES          ${trans_src}
-          PUBLIC_INCLUDES  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/trans/include>
-                           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/trans/include/ectrans>
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/algor/interface>
-                           $<INSTALL_INTERFACE:include/ectrans>
-                           $<INSTALL_INTERFACE:include>
-          PUBLIC_LIBS      parkind_${prec}
-                           fiat
-          PRIVATE_LIBS     ${ECTRANS_GPU_HIP_LIBRARIES}
-                           ${LAPACK_LIBRARIES} # we still have symbols in some files
-                           $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
-                           $<${HAVE_OMP}:OpenMP::OpenMP_Fortran>
-                           $<${HAVE_GPU_AWARE_MPI}:MPI::MPI_Fortran MPI::MPI_CXX>
+          TARGET            trans_gpu_${prec}
+          TYPE              ${GPU_LIBRARY_TYPE}
+          SOURCES           ${trans_src}
+          LINKER_LANGUAGE   Fortran
+          PUBLIC_INCLUDES   $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/trans/include>
+                            $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src/trans/include/ectrans>
+                            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/algor/interface>
+                            $<INSTALL_INTERFACE:include/ectrans>
+                            $<INSTALL_INTERFACE:include>
+          PUBLIC_LIBS       parkind_${prec}
+                            fiat
+          PRIVATE_LIBS      ${ECTRANS_GPU_HIP_LIBRARIES}
+                            ${LAPACK_LIBRARIES} # we still have symbols in some files
+                            $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
+                            $<${HAVE_OMP}:OpenMP::OpenMP_Fortran>
+                            $<${HAVE_MPI}:MPI::MPI_Fortran MPI::MPI_CXX>
           PRIVATE_DEFINITIONS
-	                   ${GPU_OFFLOAD}GPU
-	                   $<${HAVE_GPU_AWARE_MPI}:USE_CUDA_AWARE_MPI_FT>
-			   $<${HAVE_GPU_REDUCED_MEMORY}:REDUCED_MEM>
+                           ${GPU_OFFLOAD}GPU
+                           $<${HAVE_GPU_AWARE_MPI}:USE_CUDA_AWARE_MPI_FT>
+                           $<${HAVE_GPU_REDUCED_MEMORY}:REDUCED_MEM>
         )
 
         ectrans_target_fortran_module_directory(
@@ -94,6 +95,14 @@ foreach( prec dp sp )
 
         if( prec STREQUAL sp )
           target_compile_definitions( trans_gpu_${prec} PRIVATE TRANS_SINGLE PARKINDTRANS_SINGLE )
+        endif()
+
+        if( HAVE_OMP AND CMAKE_Fortran_COMPILER_ID MATCHES Cray )
+          # Propagate flags as link options for downstream targets. Only required for Cray
+          target_link_options( trans_gpu_${prec} INTERFACE
+                $<$<LINK_LANGUAGE:Fortran>:SHELL:${OpenMP_Fortran_FLAGS}>
+                $<$<LINK_LANG_AND_ID:C,Cray>:SHELL:${OpenMP_Fortran_FLAGS}>
+                $<$<LINK_LANG_AND_ID:CXX,Cray>:SHELL:${OpenMP_Fortran_FLAGS}> )
         endif()
 
   endif()


### PR DESCRIPTION
The MPI feature did not depend on actually finding MPI - which only the GPU-aware MPI did. I changed the logic to make the feature MPI depend on finding MPI, and GPU-aware MPI depend on MPI being enabled.

The GPU version currently requires MPI, thus changing the LIBRARY dependency to plain MPI being available.

Lastly, fix an issue with Cray compiler where some OpenMP symbols would not be resolved if the OpenMP dependency isn't propagated via the build interface.