### PR TITLE
Remove superfluous extra element of numll

### DIFF
--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -346,11 +346,8 @@ if (.not. lmpoff) then
   call mpl_buffer_method(kmp_type=mp_type, kmbx_size=mbx_size, kprocids=nprcids, ldinfo=(verbosity>=1))
 endif
 
-! Determine number of local levels for fourier and legendre calculations
-! based on the values of nflevg and nprtrv
-allocate(numll(nprtrv+1))
-
-! Calculate remainder
+! Determine the number of levels attributed to each member of the V set
+allocate(numll(nprtrv))
 iprused = min(nflevg+1, nprtrv)
 ilevpp = nflevg/nprtrv
 irest = nflevg -ilevpp*nprtrv
@@ -361,7 +358,6 @@ do jroc = 1, nprtrv
     numll(jroc) = ilevpp
   endif
 enddo
-numll(iprused+1:nprtrv+1) = 0
 
 nflevl = numll(mysetv)
 


### PR DESCRIPTION
This confused me when reading it. This value is never accessed so we don't need it.