### PR TITLE
Propagate pinned flag 

### DIFF
--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -125,9 +125,9 @@ foreach( prec dp sp )
         if( HAVE_ACC AND CMAKE_Fortran_COMPILER_ID MATCHES NVHPC )
           # Propagate flags as link options for downstream targets. Only required for NVHPC
           target_link_options( trans_gpu_${prec} INTERFACE
-                $<$<LINK_LANGUAGE:Fortran>:SHELL:${OpenACC_Fortran_FLAGS}>
-                $<$<LINK_LANG_AND_ID:C,NVHPC>:SHELL:${OpenACC_Fortran_FLAGS}>
-                $<$<LINK_LANG_AND_ID:CXX,NVHPC>:SHELL:${OpenACC_Fortran_FLAGS}> )
+                $<$<LINK_LANGUAGE:Fortran>:SHELL:${OpenACC_Fortran_FLAGS} -gpu=pinned>
+                $<$<LINK_LANG_AND_ID:C,NVHPC>:SHELL:${OpenACC_Fortran_FLAGS} -gpu=pinned>
+                $<$<LINK_LANG_AND_ID:CXX,NVHPC>:SHELL:${OpenACC_Fortran_FLAGS} -gpu=pinned> )
         endif()
 
   endif()


### PR DESCRIPTION
To make use of pinned memory allocations, we add the `-gpu=pinned` flag for NVHPC to setup_trans.F90:

https://github.com/ecmwf-ifs/ectrans/blob/e454b3e01fdf585008a3f2921524b0ad569e4bb1/src/trans/gpu/CMakeLists.txt#L17-L20

For this to be effective, we also need to make sure this flag ends up on the link lines of all targets that depend on ectrans. This PR propagates the flag as part of the build interface for NVHPC.