### PR TITLE
Make benchmark program name clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Optionally, tests can be run to check succesful compilation, when the feature TE
 
 The benchmark drivers are found in the bin directory.
 A brief description of available command-line arguments can be obtained with e.g.
-ectrans-benchmark-sp --help
+ectrans-benchmark-cpu-sp --help
 
 Reporting Bugs
 ==============

--- a/src/programs/CMakeLists.txt
+++ b/src/programs/CMakeLists.txt
@@ -35,7 +35,7 @@ foreach( program ectrans-benchmark ectrans-benchmark-ifs )
   if ( HAVE_CPU )
     foreach( prec dp sp )
       if( HAVE_${prec} )
-        ecbuild_add_executable( TARGET  ${program}-${prec}
+        ecbuild_add_executable( TARGET  ${program}-cpu-${prec}
                                 SOURCES ${program}.F90
                                 LINKER_LANGUAGE Fortran
                                 LIBS
@@ -43,6 +43,7 @@ foreach( program ectrans-benchmark ectrans-benchmark-ifs )
                                   parkind_${prec}
                                   trans_${prec}
         )
+        target_compile_definitions(${program}-cpu-${prec} PRIVATE VERSION="cpu")
       endif()
     endforeach( prec)
   endif()
@@ -50,15 +51,16 @@ foreach( program ectrans-benchmark ectrans-benchmark-ifs )
   if( HAVE_GPU )
     foreach( prec dp sp )
       if( HAVE_${prec} )
-            ecbuild_add_executable( TARGET  ${program}-gpu-${prec}
-                                    SOURCES ${program}.F90
-                                    LINKER_LANGUAGE Fortran
-                                    LIBS
-                                      fiat
-                                      parkind_${prec}
-                                      trans_gpu_${prec}
-            )
-       endif()
+        ecbuild_add_executable( TARGET  ${program}-gpu-${prec}
+                                SOURCES ${program}.F90
+                                LINKER_LANGUAGE Fortran
+                                LIBS
+                                  fiat
+                                  parkind_${prec}
+                                  trans_gpu_${prec}
+        )
+        target_compile_definitions(${program}-gpu-${prec} PRIVATE VERSION="gpu")
+      endif()
     endforeach( prec )
   endif( HAVE_GPU )
 endforeach( program )

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -7,7 +7,7 @@
 ! nor does it submit to any jurisdiction.
 !
 
-program transform_test
+program ectrans_benchmark
 
 !
 ! Spectral transform test
@@ -297,8 +297,8 @@ if (nspecresmin == 0) nspecresmin = nproc
 if (nprtrv > 0 .or. nprtrw > 0) then
   if (nprtrv == 0) nprtrv = nproc/nprtrw
   if (nprtrw == 0) nprtrw = nproc/nprtrv
-  if (nprtrw*nprtrv /= nproc) call abor1('transform_test:nprtrw*nprtrv /= nproc')
-  if (nprtrw > nspecresmin) call abor1('transform_test:nprtrw > nspecresmin')
+  if (nprtrw*nprtrv /= nproc) call abor1('ectrans_benchmark:nprtrw*nprtrv /= nproc')
+  if (nprtrw > nspecresmin) call abor1('ectrans_benchmark:nprtrw > nspecresmin')
 else
   do jprtrv = 4, nproc
     nprtrv = jprtrv
@@ -317,7 +317,7 @@ else
         nprtrw = max(ja, ib)
         nprtrv = min(ja, ib)
         if (nprtrw > nspecresmin ) then
-          call abor1('transform_test:nprtrw (approx square value) > nspecresmin')
+          call abor1('ectrans_benchmark:nprtrw (approx square value) > nspecresmin')
         endif
         exit
       endif
@@ -340,7 +340,7 @@ else
   iprtrv = mod(myproc - 1, nprtrv) + 1
   iprtrw = (myproc - 1)/nprtrv + 1
   if (iprtrv /= mysetv .or. iprtrw /= mysetw) then
-    call abor1('transform_test:inconsistency when computing mysetw and mysetv')
+    call abor1('ectrans_benchmark:inconsistency when computing mysetw and mysetv')
   endif
 endif
 
@@ -572,12 +572,12 @@ ztinit = (timef() - ztinit)/1000.0_jprd
 
 if (verbosity >= 0) then
   write(nout,'(" ")')
-  write(nout,'(a,i6,a,f9.2,a)') "transform_test initialisation, on",nproc,&
+  write(nout,'(a,i6,a,f9.2,a)') "ectrans_benchmark initialisation, on",nproc,&
                                 & " tasks, took",ztinit," sec"
   write(nout,'(" ")')
 endif
 
-if (iters <= 0) call abor1('transform_test:iters <= 0')
+if (iters <= 0) call abor1('ectrans_benchmark:iters <= 0')
 
 allocate(ztstep(iters))
 allocate(ztstep1(iters))
@@ -909,11 +909,11 @@ if (lstack) then
          &"   1",11x,i10)
 
     do i = 2, nproc
-      call mpl_recv(istack, ksource=nprcids(i), ktag=i, cdstring='transform_test:')
+      call mpl_recv(istack, ksource=nprcids(i), ktag=i, cdstring='ectrans_benchmark:')
       print '(i4,11x,i10)', i, istack
     enddo
   else
-    call mpl_send(istack, kdest=nprcids(1), ktag=myproc, cdstring='transform_test:')
+    call mpl_send(istack, kdest=nprcids(1), ktag=myproc, cdstring='ectrans_benchmark:')
   endif
 endif
 
@@ -1404,6 +1404,6 @@ subroutine set_ectrans_gpu_nflev(kflev)
   call ec_putenv(ECTRANS_GPU_NFLEV, overwrite=.true.)
 end subroutine
 
-end program transform_test
+end program ectrans_benchmark
 
 !===================================================================================================

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -1181,9 +1181,9 @@ subroutine print_help(unit)
   write(nout, "(a)") ""
 
   if (jprb == jprd) then
-    write(nout, "(a)") "NAME    ectrans-benchmark-dp"
+    write(nout, "(a)") "NAME    ectrans-benchmark-" // VERSION // "-dp"
   else
-    write(nout, "(a)") "NAME    ectrans-benchmark-sp"
+    write(nout, "(a)") "NAME    ectrans-benchmark-" // VERSION // "-sp"
   end if
   write(nout, "(a)") ""
 
@@ -1199,9 +1199,9 @@ subroutine print_help(unit)
 
   write(nout, "(a)") "USAGE"
   if (jprb == jprd) then
-    write(nout, "(a)") "        ectrans-benchmark-dp [options]"
+    write(nout, "(a)") "        ectrans-benchmark-" // VERSION // "-dp [options]"
   else
-    write(nout, "(a)") "        ectrans-benchmark-sp [options]"
+    write(nout, "(a)") "        ectrans-benchmark-" // VERSION // "-sp [options]"
   end if
   write(nout, "(a)") ""
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -56,48 +56,48 @@ if( HAVE_OMP )
 endif()
 
 foreach( prec dp sp )
-  if( TARGET ectrans-benchmark-${prec} )
+  if( TARGET ectrans-benchmark-cpu-${prec} )
     foreach( mpi ${ntasks} )
       foreach( omp ${nthreads} )
         set( t 47 )
         set( grid O48 )
         ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld0
-            COMMAND ectrans-benchmark-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 0 -v --meminfo --check 100
+            COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 0 -v --meminfo --check 100
             MPI ${mpi}
             OMP ${omp}
         )
         ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10
-            COMMAND ectrans-benchmark-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --meminfo --check 100
+            COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --meminfo --check 100
             MPI ${mpi}
             OMP ${omp}
         )
         ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20
-            COMMAND ectrans-benchmark-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --check 100
+            COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --check 100
             MPI ${mpi}
             OMP ${omp}
         )
         ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_scders
-            COMMAND ectrans-benchmark-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --scders --check 100
+            COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --scders --check 100
             MPI ${mpi}
             OMP ${omp}
         )
         ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_vordiv
-            COMMAND ectrans-benchmark-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --vordiv --check 100
+            COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --vordiv --check 100
             MPI ${mpi}
             OMP ${omp}
         )
         ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_vordiv_uvders
-            COMMAND ectrans-benchmark-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --vordiv --uvders --check 100
+            COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --vordiv --uvders --check 100
             MPI ${mpi}
             OMP ${omp}
         )
         ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_flt
-            COMMAND ectrans-benchmark-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --flt --check 1000
+            COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --flt --check 1000
             MPI ${mpi}
             OMP ${omp}
         )
         ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_nproma16
-            COMMAND ectrans-benchmark-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --nproma 16 --check 100
+            COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --nproma 16 --check 100
             MPI ${mpi}
             OMP ${omp}
         )


### PR DESCRIPTION
I have renamed the "default" benchmark to have "cpu" in the name. I also added preprocessing so the help message correctly reports the name of the program.