### PR TITLE
Fix typo in ordering of fields in ZGMV

### DIFF
--- a/src/programs/ectrans-benchmark-ifs.F90
+++ b/src/programs/ectrans-benchmark-ifs.F90
@@ -505,8 +505,8 @@ else
   jend_vder_EW   = jend_uv
 endif
 
-jbegin_sc = jbegin_vder_EW + 1
-jend_sc   = jbegin_vder_EW + nfld
+jbegin_sc = jend_vder_EW + 1
+jend_sc   = jend_vder_EW + nfld
 
 if (lscders) then
   ndimgmvs = 3

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -503,8 +503,8 @@ else
   jend_vder_EW   = jend_uv
 endif
 
-jbegin_sc = jbegin_vder_EW + 1
-jend_sc   = jbegin_vder_EW + nfld
+jbegin_sc = jend_vder_EW + 1
+jend_sc   = jend_vder_EW + nfld
 
 if (lscders) then
   ndimgmvs = 3


### PR DESCRIPTION
The calculation of the ordering of fields in `zgmv` is incorrect. First spotted by @marsdeno when he tried running with `--uvders --scders --vordiv` all enabled (I had never thought of testing all three at once!). The benchmark crashed with a "partially present on device" error referring to `PGP3A`.

UV-like fields and other 3D fields are both stored in the same array: `zgmv`. `zgpuv` and `zgp3a` are pointers pointing to different slices of this array, and these are subsequently passed to `inv_trans` and `dir_trans`:

```
zgpuv => zgmv(:,:,1:jend_vder_EW,:)
zgp3a => zgmv(:,:,jbegin_sc:jend_scder_EW,:)
```

([Here](https://github.com/ecmwf-ifs/ectrans/blob/redgreengpu/src/programs/ectrans-benchmark.F90#L528C1-L530C22))

Without this fix (assuming `nfld == 1`):
`jend_vder_EW` = 6, `jbegin_sc` = 6, `jend_scder_EW` = 8: UV-like fields are arrange in entries `1:6`, other 3D fields  in entries `6:8`. This is obviously wrong because the first entry of `zgp3a` is pointing to the same address as the last entry of the `zgpuv`.

The typo is [here](https://github.com/ecmwf-ifs/ectrans/blob/redgreengpu/src/programs/ectrans-benchmark.F90#L506C1-L507C34). `jbegin_vder_EW` should be `jend_vder_EW`. With this change the two pointer slices do not overlap.

Lessons learned:
- We should add a test case with ALL benchmark arguments specified, but this still wouldn't have caught this bug because...
- We should also find a way to execute the tests on a GPU-equipped machine. Is this possible with AC?