### PR TITLE
Copy original files instead of symbolic link.

### DIFF
--- a/src/transi/CMakeLists.txt
+++ b/src/transi/CMakeLists.txt
@@ -27,7 +27,7 @@ ecbuild_add_library( TARGET transi_dp
 ectrans_target_fortran_module_directory( TARGET transi_dp
   MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/module/trans_dp
 )
-file( GLOB transi_includes include/ectrans/* )
+set( transi_includes transi.h version.h )
 install(
   FILES        ${transi_includes}
   DESTINATION  include/ectrans


### PR DESCRIPTION
Addresses https://github.com/ecmwf-ifs/ectrans/issues/68.  Instead of copying the symbolic links it copies the original files that the links point to in the repository.  This results in real files in the install directory.