### PR TITLE
Rearrange the declaration of some dummy arguments

### DIFF
--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -1138,8 +1138,8 @@ end subroutine str2int
 
 subroutine sort(a, n)
 
-  real(kind=jprd), intent(inout) :: a(n)
   integer(kind=jpim), intent(in) :: n
+  real(kind=jprd), intent(inout) :: a(n)
 
   real(kind=jprd) :: x
 


### PR DESCRIPTION
This is because there are some dummy arguments declared like this:

  real(kind=jprd), intent(inout) :: a(n)
  integer(kind=jpim), intent(in) :: n

I think this counts as "n" being used before it is declared; the solution is to have "n" declared first, this is what this change does.