### PR TITLE
Set `LINKER_LANGUAGE` for benchmark executable

### DIFF
--- a/src/programs/CMakeLists.txt
+++ b/src/programs/CMakeLists.txt
@@ -34,6 +34,7 @@ foreach( prec sp dp )
   if( HAVE_${prec} )
     ecbuild_add_executable(TARGET  ectrans-benchmark-${prec}
                            SOURCES ectrans-benchmark.F90
+                           LINKER_LANGUAGE Fortran
                            LIBS
                              fiat
                              parkind_${prec}


### PR DESCRIPTION
This PR comprises of a small fix needed for static IFS builds. As I understand it, the `develop` branch is no longer bit-identical with cy49 in single-precision. Can I therefore please request this commit be tagged as 1.3.2, rather than merging into `develop` and tagging the head? Many thanks 🙏 