### PR TITLE
[redgreengpu] Fixes for CCE 17

### DIFF
--- a/src/trans/gpu/internal/uvtvd_mod.F90
+++ b/src/trans/gpu/internal/uvtvd_mod.F90
@@ -1,6 +1,6 @@
 ! (C) Copyright 1991- ECMWF.
 ! (C) Copyright 1991- Meteo-France.
-! 
+!
 ! This software is licensed under the terms of the Apache Licence Version 2.0
 ! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
 ! In applying this licence, ECMWF does not waive the privileges and immunities
@@ -102,8 +102,7 @@ I_DIV_OFFSET = 2 * KFIELD
 !$OMP& MAP(ALLOC:ZN) &
 !$OMP& MAP(TO:D_MYMS,D_NUMP,R_NTMAX) &
 !$OMP& MAP(TO:F_RN) &
-!$OMP& MAP(ALLOC:ZEPSNM) &
-!$OMP& SHARED(I_DIV_OFFSET)
+!$OMP& MAP(ALLOC:ZEPSNM,ZOA1,ZOA2)
 #endif
 
 #ifdef OMPGPU
@@ -126,7 +125,7 @@ ENDDO
 #ifdef ACCGPU
 !$ACC PARALLEL LOOP COLLAPSE(2) PRIVATE(KM,IN) DEFAULT(NONE) &
 !$ACC& COPYIN(KFIELD) &
-!$ACC& PRESENT(D_NUMP,D_MYMS,F_RN,R_NTMAX)
+!$ACC& PRESENT(D_NUMP,D_MYMS,F_RN,R_NTMAX,ZOA1)
 #endif
 DO KMLOC=1,D_NUMP
   DO J=1,2*KFIELD
@@ -142,7 +141,7 @@ ENDDO
 
 #ifdef OMPGPU
 !$OMP TARGET TEAMS DISTRIBUTE PARALLEL DO COLLAPSE(3) PRIVATE(IR,II,IN,KM,ZKM) DEFAULT(NONE) &
-!$OMP& SHARED(D_NUMP,R_NTMAX,KFIELD,D_MYMS,ZN,ZEPSNM)
+!$OMP& SHARED(D_NUMP,R_NTMAX,KFIELD,D_MYMS,ZN,ZEPSNM,I_DIV_OFFSET,ZOA1,ZOA2)
 #endif
 #ifdef ACCGPU
 !$ACC PARALLEL LOOP COLLAPSE(3) PRIVATE(IR,II,IN,KM,ZKM) DEFAULT(NONE) &


### PR DESCRIPTION
These have been obtained from vendor collaboration and supposedly fix compilation issue with  with ROCm 5.7.1, CCE 17.0.0, OMP and GPU aware MPI.

ROCm 6.1.1 seems to cause additional issues with the discovery of include paths for hipblas, hipfft and the rocm equivalents.
A potential fix is this:

```patch
diff --git a/cmake/ectrans_find_hip.cmake b/cmake/ectrans_find_hip.cmake
index 90fca11..b4142f5 100644
--- a/cmake/ectrans_find_hip.cmake
+++ b/cmake/ectrans_find_hip.cmake
@@ -110,10 +110,13 @@ macro( ectrans_find_hip )
     if( HAVE_HIP )
       list( APPEND ECTRANS_GPU_HIP_LIBRARIES ${hipblas_LIBRARIES} ${hipfft_LIBRARIES})
       list( APPEND ECTRANS_GPU_HIP_LIBRARIES ${rocblas_LIBRARIES} ${rocfft_LIBRARIES})
+      list( APPEND ECTRANS_GPU_HIP_INCLUDES ${hipblas_INCLUDE_DIRS}/hipblas ${hipfft_INCLUDE_DIRS}/hipfft)
+      list( APPEND ECTRANS_GPU_HIP_INCLUDES ${rocblas_INCLUDE_DIRS}/rocblas ${rocfft_INCLUDE_DIRS}/rocfft)
     endif()
   endif()
   ecbuild_info("HIP libraries: ${ECTRANS_GPU_HIP_LIBRARIES}")
+  ecbuild_info("HIP includes: ${ECTRANS_GPU_HIP_INCLUDES}")
 endmacro()
 macro( ectrans_declare_hip_sources )
diff --git a/src/trans/gpu/CMakeLists.txt b/src/trans/gpu/CMakeLists.txt
index 77d4e24..ad4c254 100644
--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -91,6 +91,7 @@ foreach( prec dp sp )
                                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/algor/interface>
                                $<INSTALL_INTERFACE:include/ectrans>
                                $<INSTALL_INTERFACE:include>
+                               ${ECTRANS_GPU_HIP_INCLUDES}
           PUBLIC_LIBS          parkind_${prec}
                                fiat
           PRIVATE_LIBS         ${ECTRANS_GPU_HIP_LIBRARIES}
```

However, I'm hoping there are proper library targets that could/should be used instead, and which needs to be examined once we have access to the newer software stack versions.