### PR TITLE
Deprecate COMBFLEN also for GPU

### DIFF
--- a/src/trans/gpu/external/setup_trans0.F90
+++ b/src/trans/gpu/external/setup_trans0.F90
@@ -34,7 +34,7 @@ SUBROUTINE SETUP_TRANS0(KOUT,KERR,KPRINTLEV,KMAX_RESOL,KPROMATR,&
 !     KPRGPNS - splitting level in N-S direction in grid-point space [1]
 !     KPRGPEW - splitting level in E-W direction in grid-point space [1]
 !     KPRTRW  - splitting level in wave direction in spectral space [1]
-!     KCOMBFLEN - Size of communication buffer [1800000 (*8bytes) ]
+!     KCOMBFLEN - Size of communication buffer [1800000 (*8bytes) ] (deprecated)
 !     LDMPOFF - switch off message passing [false]
 !     LDSYNC_TRANS - switch to activate barriers in trmtol trltom [false]
 !     KTRANS_SYNC_LEVEL - use of synchronization/blocking [0]
@@ -74,7 +74,7 @@ USE PARKIND1  ,ONLY : JPIM     ,JPRB, JPRD
 
 USE TPM_GEN         ,ONLY : NERR, NOUT, LMPOFF, LSYNC_TRANS, NTRANS_SYNC_LEVEL, MSETUP0, &
      &                      NMAX_RESOL, NPRINTLEV, NPROMATR, LALLOPERM
-USE TPM_DISTR       ,ONLY : LEQ_REGIONS, NCOMBFLEN, NPRGPEW,NPRGPNS, NPRTRW, NPRTRV, MYSETV
+USE TPM_DISTR       ,ONLY : LEQ_REGIONS, NPRGPEW,NPRGPNS, NPRTRW, NPRTRV, MYSETV
 USE TPM_CONSTANTS   ,ONLY : RA
 USE MPL_MODULE
 
@@ -171,7 +171,6 @@ NPRTRW = 1
 N_REGIONS_NS=1
 N_REGIONS_EW=1
 NPROMATR = 0
-NCOMBFLEN = 1800000
 LMPOFF = .FALSE.
 LSYNC_TRANS=.FALSE.
 NTRANS_SYNC_LEVEL=0
@@ -239,7 +238,10 @@ IF(PRESENT(KPRTRW)) THEN
   NPRTRW = KPRTRW
 ENDIF
 IF(PRESENT(KCOMBFLEN)) THEN
-  NCOMBFLEN = KCOMBFLEN
+  WRITE(NOUT,'(A)')
+  WRITE(NOUT,'(A)') '*** WARNING ***'
+  WRITE(NOUT,'(A)') 'KCOMBFLEN argument passed to SETUP_TRANS0 is deprecated'
+  WRITE(NOUT,'(A)')
 ENDIF
 IF(PRESENT(LDMPOFF)) THEN
   LMPOFF = LDMPOFF

--- a/src/trans/gpu/internal/tpm_distr.F90
+++ b/src/trans/gpu/internal/tpm_distr.F90
@@ -33,7 +33,6 @@ LOGICAL            :: LEQ_REGIONS ! TRUE - Use new eq_regions partitioning
 INTEGER(KIND=JPIM) :: MYPROC    ! My processor number
 INTEGER(KIND=JPIM) :: MYSETW    ! My set number in wave direction (spectral space) 
 INTEGER(KIND=JPIM) :: MYSETV    ! My set number in field direction(S.S and F.S)
-INTEGER(KIND=JPIM) :: NCOMBFLEN ! Size of communication buffer
 
 INTEGER(KIND=JPIM) :: MTAGLETR   ! Tag
 INTEGER(KIND=JPIM) :: MTAGML     ! Tag


### PR DESCRIPTION
We deprecated this for CPU, so we need to deprecate for GPU too.