### PR TITLE
No pinned flags in setup_trans

### DIFF
--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -9,19 +9,6 @@
 # Preprocess module file containing version information
 configure_file( internal/ectrans_version_mod.F90.in internal/ectrans_version_mod.F90 )
 
-## Apply workarounds for some known compilers
-
-if(CMAKE_Fortran_COMPILER_ID MATCHES "NVHPC")
-
-  # Compile setup_trans with pinned memory to improve data movement performance.
-  ectrans_add_compile_options(
-      SOURCES external/setup_trans.F90
-      #FLAGS   "-gpu=pinned,deepcopy,fastmath,nordc")
-      FLAGS   "-gpu=pinned,fastmath")
-  # TODO: check if it is sufficient to only set "-gpu=pinned" which appends rather than overwrites
-
-endif()
-
 ## Assemble sources
 
 ecbuild_list_add_pattern( LIST trans_src


### PR DESCRIPTION
I suggest that we remove pinned flags from setup_trans, mainly because there are no allocations in setup_trans anymore that are in the critical path.

The pinned flag used to be here for a few intermediate buffers that were copied forth and back in each iteration. Those are now gone.

If we are not removing pinned, we have to add it to a few more files to make sure we use the same API for deallocation. This is one of the reasons trans_release/trans_end is not working right now, and the error messages are far from intuitive.