### PR TITLE
Update paths to HIP includes to support ROCm >= 6

### DIFF
--- a/src/trans/gpu/algor/hicblas_hip.h
+++ b/src/trans/gpu/algor/hicblas_hip.h
@@ -18,7 +18,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-W#pragma-messages"
 #endif
-#include "hipblas.h"
+#include "hipblas/hipblas.h"
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/src/trans/gpu/algor/hicfft_hip.h
+++ b/src/trans/gpu/algor/hicfft_hip.h
@@ -16,7 +16,7 @@
 #pragma clang diagnostic ignored "-W#pragma-messages"
 #endif
 #include <hip/hip_runtime.h>
-#include "hipfft.h"
+#include "hipfft/hipfft.h"
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
Thanks to Paul for pointing this out.

Note that this will probably break support for < ROCm 6. Do we need to add preprocessor guards to choose the correct include for < ROCm 6? We might still need to support that on LUMI-G.