### PR TITLE
[redgreengpu] Fixed HIP include paths to support ROCm/6.0.3 on LUMI

### DIFF
--- a/src/trans/gpu/algor/external/fourier/hicfft_hip.h
+++ b/src/trans/gpu/algor/external/fourier/hicfft_hip.h
@@ -16,7 +16,7 @@
 #pragma clang diagnostic ignored "-W#pragma-messages"
 #endif
 #include <hip/hip_runtime.h>
-#include "hipfft.h"
+#include "hipfft/hipfft.h"
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/src/trans/gpu/algor/module/hicblas_hip.h
+++ b/src/trans/gpu/algor/module/hicblas_hip.h
@@ -15,7 +15,7 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-W#pragma-messages"
 #endif
-#include "hipblas.h"
+#include "hipblas/hipblas.h"
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/src/trans/gpu/algor/module/rocblasDgemmBatched.hip.cpp
+++ b/src/trans/gpu/algor/module/rocblasDgemmBatched.hip.cpp
@@ -11,7 +11,7 @@
 #pragma clang diagnostic ignored "-W#pragma-messages"
 #endif
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif

--- a/src/trans/gpu/algor/module/rocblasSgemmBatched.hip.cpp
+++ b/src/trans/gpu/algor/module/rocblasSgemmBatched.hip.cpp
@@ -8,7 +8,7 @@
 #pragma clang diagnostic ignored "-W#pragma-messages"
 #endif
 #include "hip/hip_runtime_api.h"
-#include "rocblas.h"
+#include "rocblas/rocblas.h"
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
Tried to compile on LUMI and saw that the HIP paths have changed for ROCm 6.
There is already a pull request for the develop branch, but not for the redgreengpu branch, so I created one.

Tested on LUMI using the following modules:

```bash
module load LUMI/24.03 partition/G cpe/24.03 PrgEnv-cray/8.5.0  \
    craype-x86-trento craype-accel-amd-gfx90a rocm/6.0.3 \
    cray-fftw/3.3.10.7 cray-libsci/24.03.0 buildtools/24.03
```