### PR TITLE
CMake fixes for test linker and OpenACC search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,16 @@ ecbuild_add_option( FEATURE OMP
                     DESCRIPTION "Support for OpenMP shared memory parallelism"
                     REQUIRED_PACKAGES "OpenMP COMPONENTS Fortran" )
 
-if( ${CMAKE_VERSION} VERSION_LESS "3.25" AND (NOT DEFINED ENABLE_ACC OR ENABLE_ACC ) )
-  # See https://gitlab.kitware.com/cmake/cmake/-/issues/23691, fixed in CMake 3.25
-  # (TL;DR: FindOpenACC sets OpenACC_<LANG>_FOUND correctly but does not set
-  #  OpenACC_FOUND unless all three C, CXX, and Fortran have been found - even if
-  #  only one language has been requested via COMPONENTS)
-  find_package( OpenACC COMPONENTS Fortran )
-  if( OpenACC_Fortran_FOUND )
-    set( OpenACC_FOUND ON )
+if( ${CMAKE_VERSION} VERSION_LESS "3.25" )
+  if ( ECTRANS_ENABLE_ACC OR (NOT DEFINED ECTRANS_ENABLE_ACC AND ENABLE_ACC) )
+    # See https://gitlab.kitware.com/cmake/cmake/-/issues/23691, fixed in CMake 3.25
+    # (TL;DR: FindOpenACC sets OpenACC_<LANG>_FOUND correctly but does not set
+    #  OpenACC_FOUND unless all three C, CXX, and Fortran have been found - even if
+    #  only one language has been requested via COMPONENTS)
+    find_package( OpenACC COMPONENTS Fortran )
+    if( OpenACC_Fortran_FOUND )
+      set( OpenACC_FOUND ON )
+    endif()
   endif()
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,7 +32,7 @@ if( HAVE_TESTS )
   endif()
   if( NOT HAVE_DOUBLE_PRECISION )
     list( APPEND _test_args "-DCOMPONENTS=single" )
-  endif() 
+  endif()
 
   add_test( NAME ectrans_test_install
             COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-install.sh ${_test_args} )
@@ -46,10 +46,11 @@ if( HAVE_TESTS )
   endif()
 
   ecbuild_add_executable(
-      TARGET  ectrans_test_setup_trans0
-      SOURCES trans/test_setup_trans0.F90
-      LIBS    ectrans_common
-      NOINSTALL)
+    TARGET  ectrans_test_setup_trans0
+    SOURCES trans/test_setup_trans0.F90
+    LIBS    ectrans_common
+    LINKER_LANGUAGE Fortran
+    NOINSTALL)
   set( ntasks 0 )
   if( HAVE_MPI )
     list( APPEND ntasks 1 2 )


### PR DESCRIPTION
Two small CMake fixes:
- Use the Fortran linker for ectrans_test_setup_trans0
- Only apply the OpenACC search workaround for CMake < 3.25 if the corresponding option has been requested.