### PR TITLE
Adding missing blas runtime checks

### DIFF
--- a/src/trans/gpu/algor/hicblas_gemm.hip.cpp
+++ b/src/trans/gpu/algor/hicblas_gemm.hip.cpp
@@ -252,7 +252,7 @@ void hipblas_dgemm_wrapper (char transa, char transb,
     op_t2=HIPBLAS_OP_T;
 
   if (!hip_alreadyAllocated_dgemm_handle){
-    hipblasCreate(&handle_hip_dgemm);
+    HICBLAS_CHECK(hipblasCreate(&handle_hip_dgemm));
     hip_alreadyAllocated_dgemm_handle=true;
   }
   hipblasHandle_t handle = detail::get_hipblas_handle();
@@ -281,7 +281,7 @@ void hipblas_sgemm_wrapper (char transa, char transb,
     op_t2=HIPBLAS_OP_T;
 
   if (!hip_alreadyAllocated_sgemm_handle){
-    hipblasCreate(&handle_hip_sgemm);
+    HICBLAS_CHECK(hipblasCreate(&handle_hip_sgemm));
     hip_alreadyAllocated_sgemm_handle=true;
   }
   HICBLAS_CHECK(hipblasSgemmStridedBatched(handle_hip_sgemm,op_t1,op_t2,m,n,k,


### PR DESCRIPTION
We were missing two calls to `HICBLAS_CHECK`.