### PR TITLE
Fix define to execute acc init

### DIFF
--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -1087,7 +1087,7 @@ subroutine get_command_line_arguments(nsmax, cgrid, iters, iters_warmup, nfld, n
   character(len=128) :: carg          ! Storage variable for command line arguments
   integer            :: iarg = 1      ! Argument index
 
-#ifdef ACCGPU
+#ifdef _OPENACC
   !$acc init
 #endif
 


### PR DESCRIPTION
As discussed separately, `ACCGPU` is not defined because it is PRIVATE.

`_OPENACC` is the right define to use here because it is enabled whenever the code is compiled with OpenACC support.