### PR TITLE
fix glob pattern

### DIFF
--- a/src/trans/cpu/CMakeLists.txt
+++ b/src/trans/cpu/CMakeLists.txt
@@ -44,9 +44,9 @@ function(generate_backend_sources)
 
   ecbuild_list_add_pattern( LIST files
     GLOB
-          algor/*
-          internal/*
-          external/*
+          algor/*.F90
+          internal/*.F90
+          external/*.F90
     QUIET
   )
 

--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -88,8 +88,8 @@ function(generate_backend_sources)
 
   ecbuild_list_add_pattern( LIST files
     GLOB
-          internal/*F90
-          external/*F90
+          internal/*.F90
+          external/*.F90
     QUIET
   )
   list( APPEND files

--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -88,8 +88,8 @@ function(generate_backend_sources)
 
   ecbuild_list_add_pattern( LIST files
     GLOB
-          internal/*
-          external/*
+          internal/*F90
+          external/*F90
     QUIET
   )
   list( APPEND files


### PR DESCRIPTION
```
gmake[2]: *** No rule to make target '..../src/trans/gpu/internal/.fsc_mod.F90.swp', needed by 'src/trans/gpu/generated/ectrans_gpu_sp/internal/.fsc_mod.F90.swp'.  Stop.
gmake[1]: *** [CMakeFiles/Makefile2:1020: src/trans/gpu/CMakeFiles/ectrans_gpu_sp.dir/all] Error 2
```

I have encountered this error message numerous times, and today was the tipping point, so I finally went ahead and create a proper fix. I hope I haven't missed more places with very generic patterns.