### PR TITLE
Add GPU tests

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -60,7 +60,7 @@ jobs:
               - ninja
               - ecbuild
               - prgenv/nvidia
-              - hpcx-openmpi
+              - hpcx-openmpi/2.14.0-cuda
               - fftw
             cmake_options:
               - -DENABLE_MPI=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,13 +166,16 @@ ectrans_find_lapack()
 ecbuild_add_option( FEATURE TESTS
                     DEFAULT ON
                     DESCRIPTION "Enable unit testing"
-                    REQUIRED_PACKAGES "MPI COMPONENTS Fortran"
-                    CONDITION HAVE_CPU )
+                    REQUIRED_PACKAGES "MPI COMPONENTS Fortran" )
 
-### Add sources and tests
+### Add sources
 include( ectrans_compile_options )
 add_subdirectory( src )
-add_subdirectory( tests )
+
+### Add tests
+if( HAVE_TESTS )
+  add_subdirectory( tests )
+endif()
 
 ### Export
 if( BUILD_SHARED_LIBS )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,11 @@ ecbuild_add_option( FEATURE GPU
                     DESCRIPTION "Compile GPU version of ectrans (Requires OpenACC or sufficient OpenMP offloading support)"
                     CONDITION (HAVE_HIP OR HAVE_CUDA) AND (HAVE_ACC OR HAVE_OMP) )
 
+# Check CPU or GPU is enabled, and if not, abort
+if( (NOT HAVE_CPU) AND (NOT HAVE_GPU) )
+  ecbuild_critical("Please enable one or both of the CPU and GPU features")
+endif()
+
 if( HAVE_GPU )
   if( HAVE_ACC )
     set( GPU_OFFLOAD "ACC" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,10 +142,10 @@ ecbuild_add_option( FEATURE GPU_GRAPHS_GEMM
                     CONDITION HAVE_GPU
                     DESCRIPTION "Enable graph-based optimisation of Legendre transform GEMM kernel" )
 
-	    ecbuild_add_option( FEATURE GPU_GRAPHS_FFT
+ecbuild_add_option( FEATURE GPU_GRAPHS_FFT
                     DEFAULT ON
                     CONDITION HAVE_GPU
-		    DESCRIPTION "Enable graph-based optimisation of FFT kernels" )
+                    DESCRIPTION "Enable graph-based optimisation of FFT kernels" )
 
 if( BUILD_SHARED_LIBS )
   set( GPU_STATIC_DEFAULT OFF )

--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -66,6 +66,12 @@ ecbuild_add_library(
                        $<${HAVE_GPU_GRAPHS_FFT}:USE_GRAPHS_FFT>
 )
 
+# The ecTrans libraries may be linked against an executable with the -cuda flag
+# In that case we must link with -cuda here to ensure compatibility
+target_link_options(ectrans_gpu_common PUBLIC
+  $<$<LINK_LANG_AND_ID:Fortran,NVHPC>:-cuda>
+)
+
 ectrans_target_fortran_module_directory(
   TARGET            ectrans_gpu_common
   MODULE_DIRECTORY  ${PROJECT_BINARY_DIR}/module/ectrans
@@ -155,6 +161,12 @@ foreach( prec dp sp )
                                $<${HAVE_GPU_GRAPHS_FFT}:USE_GRAPHS_FFT>
                                $<${HAVE_GPU_AWARE_MPI}:USE_GPU_AWARE_MPI>
                                ECTRANS_HAVE_MPI=${ectrans_HAVE_MPI}
+        )
+
+        # The ecTrans libraries may be linked against an executable with the -cuda flag
+        # In that case we must link with -cuda here to ensure compatibility
+        target_link_options(ectrans_gpu_${prec} PUBLIC
+          $<$<LINK_LANG_AND_ID:Fortran,NVHPC>:-cuda>
         )
 
         ectrans_target_fortran_module_directory(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,37 +6,64 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-### trans_test_install
+find_package( MPI )
 
-if( HAVE_TESTS )
+# --------------------------------------------------------------------------------------------------
+# Add a test for installation of ecTrans
+# --------------------------------------------------------------------------------------------------
 
-  find_package( MPI )
-  configure_file( test-install.sh.in ${CMAKE_CURRENT_BINARY_DIR}/test-install.sh @ONLY )
+configure_file( test-install.sh.in ${CMAKE_CURRENT_BINARY_DIR}/test-install.sh @ONLY )
 
-  unset( _test_args )
-  if( CMAKE_TOOLCHAIN_FILE )
-    list( APPEND _test_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}" )
+unset( _test_args )
+if( CMAKE_TOOLCHAIN_FILE )
+  list( APPEND _test_args "-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}" )
+endif()
+foreach( lang C CXX Fortran )
+  if( CMAKE_${lang}_COMPILER )
+    list( APPEND _test_args "-DCMAKE_${lang}_COMPILER=${CMAKE_${lang}_COMPILER}" )
   endif()
-  foreach( lang C CXX Fortran )
-    if( CMAKE_${lang}_COMPILER )
-      list( APPEND _test_args "-DCMAKE_${lang}_COMPILER=${CMAKE_${lang}_COMPILER}" )
-    endif()
-  endforeach()
-  foreach( lang C CXX Fortran )
-    if( CMAKE_${lang}_FLAGS )
-      list( APPEND _test_args "-DCMAKE_${lang}_FLAGS=${CMAKE_${lang}_FLAGS}" )
-    endif()
-  endforeach()
-  if( CMAKE_EXE_LINKER_FLAGS )
-    list( APPEND _test_args "-DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}" )
+endforeach()
+foreach( lang C CXX Fortran )
+  if( CMAKE_${lang}_FLAGS )
+    list( APPEND _test_args "-DCMAKE_${lang}_FLAGS=${CMAKE_${lang}_FLAGS}" )
   endif()
-  if( NOT HAVE_DOUBLE_PRECISION )
-    list( APPEND _test_args "-DCOMPONENTS=single" )
-  endif()
+endforeach()
+if( CMAKE_EXE_LINKER_FLAGS )
+  list( APPEND _test_args "-DCMAKE_EXE_LINKER_FLAGS=${CMAKE_EXE_LINKER_FLAGS}" )
+endif()
+if( NOT HAVE_DOUBLE_PRECISION )
+  list( APPEND _test_args "-DCOMPONENTS=single" )
+endif()
 
-  add_test( NAME ectrans_test_install
-            COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-install.sh ${_test_args} )
+add_test( NAME ectrans_test_install
+          COMMAND ${CMAKE_CURRENT_BINARY_DIR}/test-install.sh ${_test_args} )
 
+# --------------------------------------------------------------------------------------------------
+# Add a test for SETUP_TRANS0
+# --------------------------------------------------------------------------------------------------
+
+ecbuild_add_executable(
+  TARGET  ectrans_test_setup_trans0
+  SOURCES trans/test_setup_trans0.F90
+  LIBS    ectrans_common
+  LINKER_LANGUAGE Fortran
+  NOINSTALL)
+set( ntasks 0 )
+if( HAVE_MPI )
+  list( APPEND ntasks 1 2 )
+endif()
+foreach( mpi ${ntasks} )
+    ecbuild_add_test( TARGET ectrans_test_setup_trans0_mpi${mpi}
+        COMMAND ectrans_test_setup_trans0
+        MPI ${mpi}
+    )
+endforeach()
+
+# --------------------------------------------------------------------------------------------------
+# Add a test for tangent-linear/adjoint correspondence (CPU version only)
+# --------------------------------------------------------------------------------------------------
+
+if( HAVE_CPU )
   if( HAVE_DOUBLE_PRECISION )
     set( trans trans_dp )
     set( parkind parkind_dp )
@@ -44,23 +71,6 @@ if( HAVE_TESTS )
     set( trans trans_sp )
     set( parkind parkind_sp )
   endif()
-
-  ecbuild_add_executable(
-    TARGET  ectrans_test_setup_trans0
-    SOURCES trans/test_setup_trans0.F90
-    LIBS    ectrans_common
-    LINKER_LANGUAGE Fortran
-    NOINSTALL)
-  set( ntasks 0 )
-  if( HAVE_MPI )
-    list( APPEND ntasks 1 2 )
-  endif()
-  foreach( mpi ${ntasks} )
-      ecbuild_add_test( TARGET ectrans_test_setup_trans0_mpi${mpi}
-          COMMAND ectrans_test_setup_trans0
-          MPI ${mpi}
-      )
-  endforeach()
 
   ecbuild_add_test(TARGET ectrans_test_adjoint
     SOURCES trans/test_adjoint.F90
@@ -70,74 +80,130 @@ if( HAVE_TESTS )
   if( TEST ectrans_test_adjoint AND HAVE_OMP )
     target_link_libraries( ectrans_test_adjoint OpenMP::OpenMP_Fortran )
   endif()
-
-
-  foreach( prec dp sp )
-    if( TARGET ectrans-benchmark-cpu-${prec} )
-      set( ntasks 0 )
-      set( nthreads 1 )
-      if( HAVE_MPI )
-        list( APPEND ntasks 1 2 )
-      endif()
-      if( HAVE_OMP )
-        list( APPEND nthreads 4 8 )
-      endif()
-      foreach( mpi ${ntasks} )
-        foreach( omp ${nthreads} )
-          set( t 47 )
-          set( grid O48 )
-          ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld0
-              COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 0 --meminfo --check 100 --norms -v
-              MPI ${mpi}
-              OMP ${omp}
-          )
-          ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10
-              COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --meminfo --check 100 --norms -v
-              MPI ${mpi}
-              OMP ${omp}
-          )
-          ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20
-              COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --check 100 --norms -v
-              MPI ${mpi}
-              OMP ${omp}
-          )
-          ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_scders
-              COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --scders --check 100 --norms -v
-              MPI ${mpi}
-              OMP ${omp}
-          )
-          ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_vordiv
-              COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --vordiv --check 100 --norms -v
-              MPI ${mpi}
-              OMP ${omp}
-          )
-          ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_vordiv_uvders
-              COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --vordiv --uvders --check 100 --norms -v
-              MPI ${mpi}
-              OMP ${omp}
-          )
-          ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_flt
-              COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --flt --check 2000 --norms -v
-              MPI ${mpi}
-              OMP ${omp}
-          )
-          ecbuild_add_test( TARGET ectrans_test_benchmark_${prec}_T${t}_${grid}_mpi${mpi}_omp${omp}_nfld10_nlev20_nproma16
-              COMMAND ectrans-benchmark-cpu-${prec} ARGS --truncation ${t} --grid ${grid} --niter 2 --nfld 10 --nlev 20 --nproma 16 --check 100 --norms -v
-              MPI ${mpi}
-              OMP ${omp}
-          )
-        endforeach()
-      endforeach()
-    endif()
-  endforeach()
-
 endif()
 
-if( HAVE_TRANSI )
+# --------------------------------------------------------------------------------------------------
+# Add tests for common call patterns of ecTrans, using the benchmark program
+# This tests CPU and/or GPU versions, depending on which are enabled
+# --------------------------------------------------------------------------------------------------
 
+# Determine which benchmarks are available
+set( benchmarks "" )
+if( TARGET ectrans-benchmark-cpu-dp )
+  list( APPEND benchmarks ectrans-benchmark-cpu-dp )
+endif()
+if( TARGET ectrans-benchmark-cpu-sp )
+  list( APPEND benchmarks ectrans-benchmark-cpu-sp )
+endif()
+if( TARGET ectrans-benchmark-gpu-dp )
+  list( APPEND benchmarks ectrans-benchmark-gpu-dp )
+endif()
+if( TARGET ectrans-benchmark-gpu-sp )
+  list( APPEND benchmarks ectrans-benchmark-gpu-sp )
+endif()
+
+foreach( benchmark ${benchmarks} )
+  # Establish which task/thread parameters to test
+  set( ntasks 0 )
+  set( nthreads 1 )
+  if( HAVE_MPI )
+    list( APPEND ntasks 1 2 )
+  endif()
+  if( ${benchmark} MATCHES "cpu" )
+    if( HAVE_OMP )
+      list( APPEND nthreads 4 8 )
+    endif()
+  endif()
+
+  # Add test for each parameter combination
+  foreach( mpi ${ntasks} )
+    foreach( omp ${nthreads} )
+      # TCO47 truncation
+      set( t 47 )
+      set( grid O48 )
+
+      # Base arguments -> 2 iterations, memory consumption/pinning information, spectral norms, and
+      # verbose output
+      set( base_args "--niter 2 --meminfo --norms -v" )
+
+      set (base_title "${benchmark}_T${t}_${grid}_mpi${mpi}_omp${omp}")
+
+      # Check it works with 0 3D scalar fields
+      ecbuild_add_test( TARGET ${base_title}_nfld0
+          COMMAND ${benchmark}
+          ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 ${baseargs}
+          MPI ${mpi}
+          OMP ${omp}
+      )
+
+      # Check it works with 10 3D scalar fields
+      ecbuild_add_test( TARGET ${base_title}_nfld10
+          COMMAND ${benchmark}
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --check 100 ${baseargs}
+          MPI ${mpi}
+          OMP ${omp}
+      )
+
+      # Check it works with 10 3D scalar fields and 20 levels
+      ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20
+          COMMAND ${benchmark}
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --check 100 ${baseargs}
+          MPI ${mpi}
+          OMP ${omp}
+      )
+
+      # Check it works with 10 3D scalar fields, 20 levels, and scalar derivatives
+      ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_scders
+          COMMAND ${benchmark}
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --scders --check 100 ${baseargs}
+          MPI ${mpi}
+          OMP ${omp}
+      )
+
+      # Check it works with 10 3D scalar fields, 20 levels, and wind transforms
+      ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_vordiv
+          COMMAND ${benchmark}
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --vordiv --check 200  ${baseargs}
+          MPI ${mpi}
+          OMP ${omp}
+      )
+
+      # Check it works with 10 3D scalar fields, 20 levels, wind transforms, and wind derivatives
+      ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_vordiv_uvders
+          COMMAND ${benchmark}
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --vordiv --uvders --check 200 ${baseargs}
+          MPI ${mpi}
+          OMP ${omp}
+      )
+
+      # Check it works with 10 3D scalar fields, 20 levels, and NPROMA=16
+      ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_nproma16
+          COMMAND ${benchmark}
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --nproma 16 --check 100 ${baseargs}
+          MPI ${mpi}
+          OMP ${omp}
+      )
+
+      if( ${benchmark} MATCHES "cpu" )
+        # Check it works with 10 3D scalar fields, 20 levels, and the fast Legendre tranform (CPU only)
+        ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_flt
+            COMMAND ${benchmark}
+            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --flt --check 4000 ${baseargs}
+            MPI ${mpi}
+            OMP ${omp}
+        )
+      endif()
+    endforeach()
+  endforeach()
+endforeach()
+
+# --------------------------------------------------------------------------------------------------
+# Add tests for transi
+# --------------------------------------------------------------------------------------------------
+
+if( HAVE_TRANSI )
   check_include_files( malloc.h       EC_HAVE_MALLOC_H      )
   ecbuild_debug_var( EC_HAVE_MALLOC_H )
-
 
   if( EC_HAVE_MALLOC_H )
     list( APPEND  TEST_DEFINITIONS
@@ -234,11 +300,8 @@ if( HAVE_TRANSI )
     LINKER_LANGUAGE C
     ENVIRONMENT TRANS_USE_MPI=0 )
 
-  if( HAVE_TESTS )
-    ecbuild_add_option( FEATURE MEMORY_TESTS DEFAULT ON DESCRIPTION "Enable memory tests" )
-    if( NOT HAVE_MEMORY_TESTS )
-      set_tests_properties( ectrans_test_transi_memory ectrans_test_transi_memory_lonlat PROPERTIES DISABLED ON )
-    endif()
+  ecbuild_add_option( FEATURE MEMORY_TESTS DEFAULT ON DESCRIPTION "Enable memory tests" )
+  if( NOT HAVE_MEMORY_TESTS )
+    set_tests_properties( ectrans_test_transi_memory ectrans_test_transi_memory_lonlat PROPERTIES DISABLED ON )
   endif()
-
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -129,12 +129,15 @@ foreach( benchmark ${benchmarks} )
       set (base_title "${benchmark}_T${t}_${grid}_mpi${mpi}_omp${omp}")
 
       # Check it works with 0 3D scalar fields
-      ecbuild_add_test( TARGET ${base_title}_nfld0
-          COMMAND ${benchmark}
-          ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 ${baseargs}
-          MPI ${mpi}
-          OMP ${omp}
-      )
+      # This test doesn't work on GPU -> should we delete it?
+      if( NOT "${benchmark}" MATCHES "-gpu-" )
+        ecbuild_add_test( TARGET ${base_title}_nfld0
+            COMMAND ${benchmark}
+            ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 ${baseargs}
+            MPI ${mpi}
+            OMP ${omp}
+        )
+      endif()
 
       # Check it works with 10 3D scalar fields
       ecbuild_add_test( TARGET ${base_title}_nfld10


### PR DESCRIPTION
This PR tidies up the testing structure and adds tests for the GPU version.

I had to undo PR #158 as it causes a crash on our system: `invalid device buffer`.

I also had to disable the `--nfld 0` test as this fails on GPU.

This PR builds on #175.