### PR TITLE
MPI_FLOAT and MPI_DOUBLE don't exist in Fortran

### DIFF
--- a/src/trans/gpu/internal/trgtol_mod.F90
+++ b/src/trans/gpu/internal/trgtol_mod.F90
@@ -114,7 +114,7 @@ CONTAINS
     USE MPL_DATA_MODULE,        ONLY: MPL_COMM_OML
     USE OML_MOD,                ONLY: OML_MY_THREAD
 #if ECTRANS_HAVE_MPI
-    USE MPI_F08,                ONLY: MPI_COMM, MPI_REQUEST, MPI_FLOAT, MPI_DOUBLE
+    USE MPI_F08,                ONLY: MPI_COMM, MPI_REQUEST, MPI_REAL4, MPI_REAL8
     ! Missing: MPI_ISEND, MPI_IRECV on purpose due to cray-mpi bug (see https://github.com/ecmwf-ifs/ectrans/pull/157)
 #endif
     USE TPM_STATS,              ONLY: GSTATS => GSTATS_NVTX
@@ -187,9 +187,9 @@ CONTAINS
 
 
 #ifdef PARKINDTRANS_SINGLE
-#define TRGTOL_DTYPE MPI_FLOAT
+#define TRGTOL_DTYPE MPI_REAL4
 #else
-#define TRGTOL_DTYPE MPI_DOUBLE
+#define TRGTOL_DTYPE MPI_REAL8
 #endif
 
 #if ECTRANS_HAVE_MPI

--- a/src/trans/gpu/internal/trltog_mod.F90
+++ b/src/trans/gpu/internal/trltog_mod.F90
@@ -115,7 +115,7 @@ CONTAINS
     USE OML_MOD,                ONLY: OML_MY_THREAD
     USE ABORT_TRANS_MOD,        ONLY: ABORT_TRANS
 #if ECTRANS_HAVE_MPI
-    USE MPI_F08,                ONLY: MPI_COMM, MPI_REQUEST, MPI_FLOAT, MPI_DOUBLE
+    USE MPI_F08,                ONLY: MPI_COMM, MPI_REQUEST, MPI_REAL4, MPI_REAL8
     ! Missing: MPI_ISEND, MPI_IRECV on purpose due to cray-mpi bug (see https://github.com/ecmwf-ifs/ectrans/pull/157)
 #endif
     USE TPM_STATS,              ONLY: GSTATS => GSTATS_NVTX
@@ -197,9 +197,9 @@ CONTAINS
 #endif
 
 #ifdef PARKINDTRANS_SINGLE
-#define TRLTOG_DTYPE MPI_FLOAT
+#define TRLTOG_DTYPE MPI_REAL4
 #else
-#define TRLTOG_DTYPE MPI_DOUBLE
+#define TRLTOG_DTYPE MPI_REAL8
 #endif
 #if ECTRANS_HAVE_MPI
     IF(.NOT. LMPOFF) THEN

--- a/src/trans/gpu/internal/trltom_mod.F90
+++ b/src/trans/gpu/internal/trltom_mod.F90
@@ -94,7 +94,7 @@ CONTAINS
     USE TPM_DISTR,              ONLY: D, NPRTRW, NPROC, MYPROC, MYSETW
     USE TPM_GEN,                ONLY: LSYNC_TRANS, NERR, LMPOFF
 #if ECTRANS_HAVE_MPI
-    USE MPI_F08,                ONLY: MPI_COMM, MPI_FLOAT, MPI_DOUBLE
+    USE MPI_F08,                ONLY: MPI_COMM, MPI_REAL4, MPI_REAL8
     ! Missing: MPI_ALLTOALLV on purpose due to cray-mpi bug (see https://github.com/ecmwf-ifs/ectrans/pull/157)
 #endif
     USE TPM_STATS,              ONLY: GSTATS => GSTATS_NVTX
@@ -120,9 +120,9 @@ CONTAINS
 #endif
 
 #ifdef PARKINDTRANS_SINGLE
-#define TRLTOM_DTYPE MPI_FLOAT
+#define TRLTOM_DTYPE MPI_REAL4
 #else
-#define TRLTOM_DTYPE MPI_DOUBLE
+#define TRLTOM_DTYPE MPI_REAL8
 #endif
 
 #if ECTRANS_HAVE_MPI

--- a/src/trans/gpu/internal/trmtol_mod.F90
+++ b/src/trans/gpu/internal/trmtol_mod.F90
@@ -94,7 +94,7 @@ CONTAINS
     USE TPM_DISTR,              ONLY: D, NPRTRW, NPROC, MYPROC, MYSETW
     USE TPM_GEN,                ONLY: LSYNC_TRANS, NERR, LMPOFF
 #if ECTRANS_HAVE_MPI
-    USE MPI_F08,                ONLY: MPI_COMM, MPI_FLOAT, MPI_DOUBLE
+    USE MPI_F08,                ONLY: MPI_COMM, MPI_REAL4, MPI_REAL8
     ! Missing: MPI_ALLTOALLV on purpose due to cray-mpi bug (see https://github.com/ecmwf-ifs/ectrans/pull/157)
 #endif
     USE BUFFERED_ALLOCATOR_MOD, ONLY: BUFFERED_ALLOCATOR, ASSIGN_PTR, GET_ALLOCATION
@@ -121,9 +121,9 @@ CONTAINS
 #endif
 
 #ifdef PARKINDTRANS_SINGLE
-#define TRMTOL_DTYPE MPI_FLOAT
+#define TRMTOL_DTYPE MPI_REAL4
 #else
-#define TRMTOL_DTYPE MPI_DOUBLE
+#define TRMTOL_DTYPE MPI_REAL8
 #endif
 
 #if ECTRANS_HAVE_MPI


### PR DESCRIPTION
With NVHPC 24.1 and NVHPC's shipped MPI, I could not compile the Fortran files referencing `MPI_DOUBLE` and `MPI_FLOAT`. And indeed the MPI_Fortran standard does not include these, but rather `MPI_REAL4` and `MPI_REAL8`.

I have adapted offending routines.