### PR TITLE
Fix omp update directive in trgtol_mod (no MPI code path)

### DIFF
--- a/src/trans/gpu/internal/trgtol_mod.F90
+++ b/src/trans/gpu/internal/trgtol_mod.F90
@@ -650,7 +650,7 @@ CONTAINS
 #endif
 #else
 #ifdef OMPGPU
-    !$OMP TARGET DATA UPDATE FROM(ZCOMBUFS) IF(ISEND_COUNTS > 0)
+    !$OMP TARGET UPDATE FROM(ZCOMBUFS) IF(ISEND_COUNTS > 0)
 #endif
 #ifdef ACCGPU
     !! this is safe-but-slow fallback for running without GPU-aware MPI


### PR DESCRIPTION
This is a very minor PR correcting an OMP directive when building ECTrans without MPI, for PR #211

I used the test program from @samhatfield's comment [here](https://github.com/ecmwf-ifs/ectrans/pull/211#issuecomment-2648227585) to verify the OMP implementation on the GPU on MI300A with and without unified memory enabled. I am getting identical results in both cases!

Here are the results running on MI300A in "discrete GPU" mode (HSA_XNACK=0):
single precision:
```
ecTrans at version: 1.5.1
commit: 59c7ff9739dac8e1332f7c788dbbe3f67a929eb1

 R%NTMAX= 79
 R%NSMAX= 79
 setup_trans: sizes1 NUMP= 80
 Using OpenMP offloading
    FG%ZAS:       611840B
    FG%ZAA:       611840B
   FG%ZAS0:        26240B
   FG%ZAA0:        25600B
 FG%ZEPSNM:        26240B
 ===GPU arrays successfully allocated
 GRID_POINT_FIELD =  -3.66075754,  3.66075754
 TEST_PROGRAM 1
 Error =  2.612723335E-7
```
double precision:
```
ecTrans at version: 1.5.1
commit: 59c7ff9739dac8e1332f7c788dbbe3f67a929eb1

 R%NTMAX= 79
 R%NSMAX= 79
 setup_trans: sizes1 NUMP= 80
 Using OpenMP offloading
    FG%ZAS:      1223680B
    FG%ZAA:      1223680B
   FG%ZAS0:        26240B
   FG%ZAA0:        25600B
 FG%ZEPSNM:        52480B
 ===GPU arrays successfully allocated
 GRID_POINT_FIELD =  -3.6607575710598272,  3.6607575710598272
 TEST_PROGRAM 1
 Error =  8.00660226648715344E-15
```

With unified memory enabled (HSA_XNACK=1):
single precision:
```
ecTrans at version: 1.5.1
commit: 59c7ff9739dac8e1332f7c788dbbe3f67a929eb1

 R%NTMAX= 79
 R%NSMAX= 79
 setup_trans: sizes1 NUMP= 80
 Using OpenMP offloading
    FG%ZAS:       611840B
    FG%ZAA:       611840B
   FG%ZAS0:        26240B
   FG%ZAA0:        25600B
 FG%ZEPSNM:        26240B
 ===GPU arrays successfully allocated
 GRID_POINT_FIELD =  -3.66075754,  3.66075754
 TEST_PROGRAM 1
 Error =  2.612723335E-7
```
double precision:
```
ecTrans at version: 1.5.1
commit: 59c7ff9739dac8e1332f7c788dbbe3f67a929eb1

 R%NTMAX= 79
 R%NSMAX= 79
 setup_trans: sizes1 NUMP= 80
 Using OpenMP offloading
    FG%ZAS:      1223680B
    FG%ZAA:      1223680B
   FG%ZAS0:        26240B
   FG%ZAA0:        25600B
 FG%ZEPSNM:        52480B
 ===GPU arrays successfully allocated
 GRID_POINT_FIELD =  -3.6607575710598272,  3.6607575710598272
 TEST_PROGRAM 1
 Error =  8.00660226648715344E-15
```