### PR TITLE
Fix some formats in ectrans-benchmark.F90

### DIFF
--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -738,12 +738,12 @@ do jstep = 1, iters+iters_warmup
           zerr(4) = abs(znormt1(ifld)/znormt(ifld) - 1.0_jprb)
           zmaxerr(4) = max(zmaxerr(4), zerr(4))
         enddo
-        write(nout,'("time step ",i6," took", f8.4," | zspvor max err="e10.3,&
-                    & " | zspdiv max err="e10.3," | zspsc3a max err="e10.3," | zspsc2 max err="e10.3)') &
+        write(nout,'("time step ",i6," took", f8.4," | zspvor max err=",e10.3,&
+                    & " | zspdiv max err=",e10.3," | zspsc3a max err=",e10.3," | zspsc2 max err=",e10.3)') &
                     &  jstep, ztstep(jstep), zmaxerr(3), zmaxerr(2), zmaxerr(4), zmaxerr(1)
       else
-        write(nout,'("time step ",i6," took", f8.4," | zspvor max err="e10.3,&
-                    & " | zspdiv max err="e10.3," | zspsc2 max err="e10.3)') &
+        write(nout,'("time step ",i6," took", f8.4," | zspvor max err=",e10.3,&
+                    & " | zspdiv max err=",e10.3," | zspsc2 max err=",e10.3)') &
                     &  jstep, ztstep(jstep), zmaxerr(3), zmaxerr(2), zmaxerr(1)
       endif
     endif


### PR DESCRIPTION
There are some commas missing in i/o formats in ectrans-benchmark.F90, I have fixed them here.  Addresses #232.