### PR TITLE
MPI-free testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,10 +174,6 @@ ecbuild_add_option( FEATURE ECTRANS4PY
 
 ectrans_find_lapack()
 
-ecbuild_add_option( FEATURE TESTS
-                    DEFAULT ON
-                    DESCRIPTION "Enable unit testing" )
-
 ### Add sources
 include( ectrans_compile_options )
 add_subdirectory( src )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,8 +176,7 @@ ectrans_find_lapack()
 
 ecbuild_add_option( FEATURE TESTS
                     DEFAULT ON
-                    DESCRIPTION "Enable unit testing"
-                    REQUIRED_PACKAGES "MPI COMPONENTS Fortran" )
+                    DESCRIPTION "Enable unit testing" )
 
 ### Add sources
 include( ectrans_compile_options )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,8 +6,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-find_package( MPI )
-
 # --------------------------------------------------------------------------------------------------
 # Add a test for installation of ecTrans
 # --------------------------------------------------------------------------------------------------


### PR DESCRIPTION
If possible, MPI should not be a requirement for the TESTS feature. At the moment we can't build ecTrans with amdflang and MPI (at least not with OpenMPI). For now we will disable MPI in the CI when building with amdflang. We still want to run the remaining serial test suite when building with amdflang though.