### PR TITLE
Properly qualify work and output dirs for repeated actions

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -78,8 +78,8 @@ jobs:
               - rocm/6.0.3
               - cray-fftw
               - buildtools
-            output_dir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}
-            workdir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}
+            output_dir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
+            workdir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
             cmake_options: >
               -DOpenMP_C_LIB_NAMES=craymp -DOpenMP_CXX_LIB_NAMES=craymp
               -DOpenMP_Fortran_LIB_NAMES=craymp -DOpenMP_craymp_LIBRARY=craymp


### PR DESCRIPTION
On LUMI-G, actions currently take place in the following directory:
```
/scratch/{project}/github-actions/ectrans/{pipeline ID}
```
There is no qualification for repeated runs of the same action, e.g. if the action fails and needs to be repeated. This means the repeated action fails because it assumes it's running in a clean directory. See e.g. [this action](https://github.com/ecmwf-ifs/ectrans/actions/runs/14265546118/job/40086431362?pr=249):
```
/scratch/***/github-actions/ectrans/14265546118/ecmwf/ecbuild /scratch/***/github-actions/ectrans/14265546118
+ git init
Reinitialized existing Git repository in /pfs/lustrep4/scratch/***/github-actions/ectrans/14265546118/ecmwf/ecbuild/.git/
+ git remote add origin https://github.com/ecmwf/ecbuild
error: remote origin already exists.
```

This PR attempts to fix this by instead running actions in:
```
/scratch/{project}/github-actions/ectrans/{pipeline ID}/{run_attempt}
```
using the `github.run_attempt` context variable.