### PR TITLE
Change LUMI-G CI sbatch parameters

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -64,11 +64,11 @@ jobs:
             troika_user_secret: LUMI_CI_SSH_USER
             account_secret: LUMI_CI_PROJECT
             sbatch_options: |
-              #SBATCH --time=00:20:00
+              #SBATCH --time=00:40:00
               #SBATCH --nodes=1
               #SBATCH --ntasks-per-node=8
               #SBATCH --gpus-per-task=1
-              #SBATCH --partition=dev-g
+              #SBATCH --partition=standard-g
               #SBATCH --account={0}
             modules:
               - CrayEnv


### PR DESCRIPTION
I noticed that tests on LUMI-G were timing out as they can sometimes take longer than 20 minutes. This PR increases the CI job time limit to 40 minutes. It also submits jobs to `standard-g` instead of `dev-g` (the GPU development queue) as the latter only permits one job at a time.