### PR TITLE
Refactor CMake FFTW logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,22 +70,26 @@ endif()
 set( HAVE_dp ${HAVE_DOUBLE_PRECISION} )
 set( HAVE_sp ${HAVE_SINGLE_PRECISION} )
 
-ecbuild_add_option( FEATURE MKL
-                    DESCRIPTION "Use MKL for BLAS and/or FFTW"
-                    DEFAULT ON
-                    REQUIRED_PACKAGES "MKL QUIET" )
-
-if( NOT HAVE_MKL )
-    option( FFTW_ENABLE_MKL OFF )
-endif()
-
 ecbuild_add_option( FEATURE CPU
                     DEFAULT ON
                     DESCRIPTION "Compile CPU version of ectrans"
                    )
 
+ecbuild_add_option( FEATURE MKL
+                    DESCRIPTION "Use MKL for BLAS"
+                    DEFAULT ON
+                    CONDITION HAVE_CPU
+                    REQUIRED_PACKAGES "MKL QUIET" )
+
+ecbuild_add_option( FEATURE FFTW_MKL
+                    DESCRIPTION "Use MKL for FFTW"
+                    DEFAULT OFF
+                    CONDITION HAVE_MKL )
+
 if( HAVE_CPU )
-  ecbuild_find_package( NAME FFTW REQUIRED COMPONENTS double ${single} )
+  if( NOT HAVE_FFTW_MKL )
+    ecbuild_find_package( NAME FFTW REQUIRED COMPONENTS double ${single} )
+  endif()
 endif()
 
 ecbuild_add_option( FEATURE TRANSI


### PR DESCRIPTION
It's not currently possible to use MKL for to satisfy both LAPACK and FFTW without still requiring libfftw*. If MKL provides both, then we don't need libfftw. This PR attempts to clarify the logic, implementing this flow chart:

```mermaid
graph TD;
    A[HAVE_MKL] -->|NO| B(FFTW/LAPACK);
    A[HAVE_MKL] -->|YES| C[HAVE_FFTW_MKL];
    C[HAVE_FFTW_MKL] -->|YES| D(MKL/MKL);
    C[HAVE_FFTW_MKL] -->|NO| E(FFTW/MKL);
```

Three configurations are supported:
1. MKL is disabled (`-DENABLE_MKL=OFF`). With this, libfftw and a LAPACK library must be provided.
2. MKL is enabled for BLAS only (`-DENABLE_MKL=ON` (default)). With this, libfftw is still used for FFTW and must still be provided but MKL is used as the BLAS library.
3. MKL is enabled for both BLAS and FFTW (`-DENABLE_MKL=ON (default) -DENABLE_FFTW_MKL=ON`). With this, no libfftw needs to be provided. **This configuration is not possible without this PR.**


\* Here I refer to the common library which implements FFTW as libfftw and the abstract specification as FFTW.