### PR TITLE
Restore compatibility with IFS -> hotfix/1.6.2

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -64,9 +64,10 @@ jobs:
             troika_user_secret: LUMI_CI_SSH_USER
             account_secret: LUMI_CI_PROJECT
             sbatch_options: |
-              #SBATCH --time=00:20:00
+              #SBATCH --time=00:40:00
               #SBATCH --nodes=1
               #SBATCH --ntasks-per-node=8
+              #SBATCH --cpus-per-task=7
               #SBATCH --gpus-per-task=1
               #SBATCH --partition=dev-g
               #SBATCH --account={0}

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -89,7 +89,7 @@ jobs:
               - ROCFFT_RTC_CACHE_PATH=$PWD/rocfft_kernel_cache.db
               - MPICH_GPU_SUPPORT_ENABLED=1
               - MPICH_SMP_SINGLE_COPY_MODE=NONE
-
+              - CMAKE_BUILD_PARALLEL_LEVEL=1
 
     runs-on: [self-hosted, linux, hpc]
     env:

--- a/src/etrans/cpu/CMakeLists.txt
+++ b/src/etrans/cpu/CMakeLists.txt
@@ -70,11 +70,11 @@ foreach( prec dp sp )
 
     set( FFTW_LINK PRIVATE )
     if( LAPACK_LIBRARIES MATCHES "mkl" AND NOT FFTW_LIBRARIES MATCHES "mkl" )
-        ecbuild_warn( "Danger: Both MKL and FFTW are linked in trans_${prec}. "
+        ecbuild_warn( "Danger: Both MKL and FFTW are linked in ectrans_etrans_${prec}. "
                       "No guarantees on link order can be made for the final executable.")
         set( FFTW_LINK PUBLIC ) # Attempt anyway to give FFTW precedence
     endif()
-    ecbuild_debug("target_link_libraries( trans_${prec} ${FFTW_LINK} ${FFTW_LIBRARIES} )")
+    ecbuild_debug("target_link_libraries( ectrans_etrans_${prec} ${FFTW_LINK} ${FFTW_LIBRARIES} )")
     target_link_libraries( ectrans_etrans_${prec} ${FFTW_LINK} ${FFTW_LIBRARIES} )
     target_include_directories( ectrans_etrans_${prec} PRIVATE ${FFTW_INCLUDE_DIRS} )
     target_compile_definitions( ectrans_etrans_${prec} PRIVATE WITH_FFTW )
@@ -83,15 +83,15 @@ foreach( prec dp sp )
     #target_link_libraries( ectrans_${prec} PRIVATE ${LAPACK_LIBRARIES} )
 
     if( HAVE_OMP )
-      ecbuild_debug("target_link_libraries( ectrans_${prec} PRIVATE OpenMP::OpenMP_Fortran )")
-      target_link_libraries( ectrans_${prec} PRIVATE OpenMP::OpenMP_Fortran )
+      ecbuild_debug("target_link_libraries( ectrans_etrans_${prec} PRIVATE OpenMP::OpenMP_Fortran )")
+      target_link_libraries( ectrans_etrans_${prec} PRIVATE OpenMP::OpenMP_Fortran )
     endif()
 
     # This interface library is for backward compatibility, and provides the older includes
     ecbuild_add_library( TARGET etrans_${prec} TYPE INTERFACE )
     target_include_directories( etrans_${prec} INTERFACE $<BUILD_INTERFACE:${BUILD_INTERFACE_INCLUDE_DIR}/etrans_${prec}> )
     target_include_directories( etrans_${prec} INTERFACE $<INSTALL_INTERFACE:include/ectrans/etrans_${prec}> )
-    target_link_libraries( trans_${prec} INTERFACE fiat ectrans_${prec} ectrans_etrans_${prec} parkind_${prec})
+    target_link_libraries( etrans_${prec} INTERFACE ectrans_etrans_${prec} )
   endif()
 endforeach()
 

--- a/src/programs/CMakeLists.txt
+++ b/src/programs/CMakeLists.txt
@@ -57,6 +57,7 @@ if( HAVE_ETRANS )
     if( HAVE_${prec} )
       ecbuild_add_executable( TARGET  ectrans-lam-benchmark-cpu-${prec}
                               SOURCES ectrans-lam-benchmark.F90
+                              LINKER_LANGUAGE Fortran
                               LIBS
                                 fiat
                                 parkind_${prec}

--- a/src/transi/CMakeLists.txt
+++ b/src/transi/CMakeLists.txt
@@ -22,6 +22,7 @@ ecbuild_add_library( TARGET transi_dp
   PUBLIC_INCLUDES     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
                       $<INSTALL_INTERFACE:include>
   PRIVATE_LIBS        trans_dp
+                      $<${ectrans_HAVE_ETRANS}:etrans_dp>
   PRIVATE_DEFINITIONS ECTRANS_HAVE_MPI=${ectrans_HAVE_MPI}
 )
 ectrans_target_fortran_module_directory( TARGET transi_dp


### PR DESCRIPTION
See also #293 :

> Two conceptual modifications:
>
> - The changes in https://github.com/ecmwf-ifs/ectrans/commit/b0475fd8d13609f9f603a888205df7d2d2caa5fd broke use >in IFS, thus reverting this change.
> - The CMake for etrans used wrong target names in several places, resulting in missing headers when using etrans > interface includes in IFS.