### PR TITLE
Fix for cublas link failures

### DIFF
--- a/cmake/ectrans_find_cuda.cmake
+++ b/cmake/ectrans_find_cuda.cmake
@@ -21,5 +21,18 @@ macro( ectrans_find_cuda )
       ecbuild_info( "cuda arch               : [${CMAKE_CUDA_ARCHITECTURES}]" )
       ecbuild_info( "cublas                  : [${CUDA_cublas_LIBRARY}]" )
       ecbuild_info( "cufft                   : [${CUDA_cufft_LIBRARY}]" )
+
+      if( TARGET CUDA::cublas )
+         # When looking for CUDAToolkit, the various components are found using find_library
+         # which sets the target to the full path, but the parent directory is not added
+         # to the target's LINK_DIRECTORIES property. Whilst in principle this should be enough
+         # to link to the CUDA libraries, as the full path appears on the link line, it seems
+         # there is a transient dependency somewhere that also requires the directory path to be set.
+         # This symptom only manifests on systems where libcudart lives in a separate location to
+         # libcublas. It is unclear whether this is an nvhpc or a cmake bug, but nevertheless manually
+         # specifying the linkk directory here should be harmless.
+         cmake_path(GET CUDA_cublas_LIBRARY PARENT_PATH _cublas_path)
+         target_link_directories( CUDA::cublas INTERFACE ${_cublas_path} )
+      endif()
     endif()
 endmacro()

--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -56,8 +56,8 @@ ecbuild_add_library(
                        $<INSTALL_INTERFACE:include/ectrans>
                        $<INSTALL_INTERFACE:include>
   PUBLIC_LIBS          fiat ectrans_common
-  PRIVATE_LIBS         ${ECTRANS_GPU_HIP_LIBRARIES}
-                       $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
+                       ${ECTRANS_GPU_HIP_LIBRARIES}
+  PRIVATE_LIBS         $<${HAVE_ACC}:OpenACC::OpenACC_Fortran>
                        $<${HAVE_OMP}:OpenMP::OpenMP_Fortran>
                        $<${HAVE_CUTLASS}:nvidia::cutlass::cutlass>
   PRIVATE_DEFINITIONS  ${GPU_RUNTIME}GPU ${GPU_OFFLOAD}GPU


### PR DESCRIPTION
When building on systems where libcublas lives in a different folder to libcudart, ectrans suffers from link failures. In such a configuration, FindCudaToolkit.cmake correctly finds cublas and sets the target `CUDA::cublas` to the full path of this library. It is this full path to ectrans that appears on the link line. However when building the executable, the linker tries to simply link to `-lcublas` (even though this isn't on the link line, hence my suspicion that it's a transient dependency) and therefore expects the cublas parent directory to also be on the link line  i.e. `-L<path-to-cublas-dir>`. FindCudaToolkit.cmake however only adds the cudart parent directory to the link line, not that of cublas.

This PR addresses the above and also adds the parent directory of `-lcublas` to the link line. Ultimately this should probably be a patch to FindCudaToolkit.cmake but it should be harmless to also include it here.