### PR TITLE
Reduce test set size

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -281,7 +281,7 @@ foreach( benchmark ${benchmarks} )
         # Check it works with 10 3D scalar fields, 20 levels, and vordiv in grid point space
         ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_vordiv
             COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --vordiv --check 200  --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_vordiv ${base_args}
+            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --vordiv --check 100  --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_vordiv ${base_args}
             MPI ${mpi}
             OMP ${omp}
         )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -252,16 +252,13 @@ foreach( benchmark ${benchmarks} )
       foreach( callmode 1 2 )
         set (base_title "${benchmark}_T${t}_${grid}_mpi${mpi}_omp${omp}_callmode${callmode}")
         # Check it works with 0 3D scalar fields
-        # This test doesn't work on GPU -> should we delete it?
-        if( NOT "${benchmark}" MATCHES "-gpu-" )
-          ecbuild_add_test( TARGET ${base_title}_nfld0
-              COMMAND ${benchmark}
-              ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld0 ${base_args}
-              MPI ${mpi}
-              OMP ${omp}
-          )
-          ectrans_set_test_properties( ${base_title}_nfld0 )
-        endif()
+        ecbuild_add_test( TARGET ${base_title}_nfld0
+            COMMAND ${benchmark}
+            ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld0 ${base_args}
+            MPI ${mpi}
+            OMP ${omp}
+        )
+        ectrans_set_test_properties( ${base_title}_nfld0 )
 
         # Check it works with 10 3D scalar fields
         ecbuild_add_test( TARGET ${base_title}_nfld10

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -266,7 +266,7 @@ foreach( benchmark ${benchmarks} )
         # Check it works with 10 3D scalar fields
         ecbuild_add_test( TARGET ${base_title}_nfld10
             COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 --callmode ${callmode} ${base_args} --dump-checksums ${base_title}_nfld10 ${base_args}
+            ARGS --truncation ${t} --grid ${grid} --nfld 10 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10 ${base_args}
             MPI ${mpi}
             OMP ${omp}
         )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -330,7 +330,7 @@ if( HAVE_ETRANS )
         list( APPEND ntasks 1 2 )
       endif()
       if( HAVE_OMP )
-        list( APPEND nthreads 4 8 )
+        list( APPEND nthreads 8 )
       endif()
 
       # Base arguments -> nlat x nlon, 2 iterations, memory consumption/pinning information,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -260,15 +260,6 @@ foreach( benchmark ${benchmarks} )
         )
         ectrans_set_test_properties( ${base_title}_nfld0 )
 
-        # Check it works with 10 3D scalar fields
-        ecbuild_add_test( TARGET ${base_title}_nfld10
-            COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 10 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10 ${base_args}
-            MPI ${mpi}
-            OMP ${omp}
-        )
-        ectrans_set_test_properties( ${base_title}_nfld10 )
-
         # Check it works with 10 3D scalar fields and 20 levels
         ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20
             COMMAND ${benchmark}
@@ -278,14 +269,14 @@ foreach( benchmark ${benchmarks} )
         )
         ectrans_set_test_properties( ${base_title}_nfld10_nlev20 )
 
-        # Check it works with 10 3D scalar fields, 20 levels, and scalar derivatives
-        ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_scders
+        # Check it works with 10 3D scalar fields, 20 levels, and derivatives
+        ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_derivatives
             COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --scders --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_scders ${base_args}
+            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --scders --uvders --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_derivatives ${base_args}
             MPI ${mpi}
             OMP ${omp}
         )
-        ectrans_set_test_properties( ${base_title}_nfld10_nlev20_scders )
+        ectrans_set_test_properties( ${base_title}_nfld10_nlev20_derivatives )
 
         # Check it works with 10 3D scalar fields, 20 levels, and vordiv in grid point space
         ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_vordiv
@@ -295,15 +286,6 @@ foreach( benchmark ${benchmarks} )
             OMP ${omp}
         )
         ectrans_set_test_properties( ${base_title}_nfld10_nlev20_vordiv )
-
-        # Check it works with 10 3D scalar fields, 20 levels, vordiv in grid point space, and wind derivatives
-        ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_vordiv_uvders
-            COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --vordiv --uvders --check 200 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_vordiv ${base_args}
-            MPI ${mpi}
-            OMP ${omp}
-        )
-        ectrans_set_test_properties( ${base_title}_nfld10_nlev20_vordiv_uvders )
 
         # Check it works with 10 3D scalar fields, 20 levels, and NPROMA=16
         ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_nproma16

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -234,7 +234,7 @@ foreach( benchmark ${benchmarks} )
   endif()
   if( ${benchmark} MATCHES "cpu" )
     if( HAVE_OMP )
-      list( APPEND nthreads 4 8 )
+      list( APPEND nthreads 8 )
     endif()
   endif()
 


### PR DESCRIPTION
Currently there are 530 tests executed for the GPU CI actions which is starting to reach the reasonable limit in terms of the job wall time on the HPC systems these actions run on. Here is the breakdown for the 530 tests:
- 1: ectrans_test_install
- 3: ectrans_test_setup_trans0
- 6: ectrans_test_adjoint
- 12: ectrans_test_{dir/inv}trans_adjoint
- 6: ectrans_test_gpnorm_trans_adjoint
- 288: benchmark tests (CPU)
- 72: benchmark tests (GPU)
- 126: LAM benchmark tests (CPU)
- 16: transi tests

The big one is the CPU benchmark tests. For each precision in "dp sp", for each ntasks in "0 1 2", for each nthreads in "1 4 8", and for each callmode in "1 2", we execute the following:
- benchmark with nfld 0
- benchmark with nfld 10
- benchmark with nfld 10 and nlev 20
- benchmark with nfld10, nlev 20 and scders
- benchmark with nfld 10, nlev 20 and vordiv
- benchmark with nfld 10, nlev 20, vordiv, and uvders
- benchmark with nfld 10, nlev 20, nproma 16
- benchmark with nfld 10, nlev 20, flt

I don't think we need to do all of these. Instead I suggest we do just:
- benchmark with nfld 1, nlev 137, scders, vordiv, uvders
- benchmark with nfld 1, nlev 137, scders, vordiv, uvders and nproma 16
- benchmark with nfld 1, nlev 137, scders, vordiv, uvders and flt

This brings the total number of tests down to 302. These consolidated tests mostly have the same coverage as the old ones, except that there's no nfld 0 test, but do we actually care about that?

We could probably reduce the 126 LAM tests as well (especially as we'll be adding GPU LAM tests at some point).