### PR TITLE
Remove dead code from previous GPU version

### DIFF
--- a/src/programs/ectrans-benchmark-ifs.F90
+++ b/src/programs/ectrans-benchmark-ifs.F90
@@ -400,10 +400,6 @@ call setup_trans0(kout=nout, kerr=nerr, kprintlev=merge(2, 0, verbosity == 1),  
 call gstats(1, 1)
 
 call gstats(2, 0)
-! IFS spectral fields are dimensioned NFLEVL, Nils !!
-call set_ectrans_gpu_nflev(nflevl)
-  ! We pass nflevl via environment variable in order not to change API
-  ! In long run, ectrans should grow its internal buffers automatically
 call setup_trans(ksmax=nsmax, kdgl=ndgl, kloen=nloen, ldsplit=.true.,       &
   &              ldusefftw=lfftw, lduserpnm=luserpnm, ldkeeprpnm=lkeeprpnm, &
   &              lduseflt=luseflt)
@@ -1490,17 +1486,6 @@ subroutine gstats_labels
   call gstats_label(400, '   ', 'GSTATS         - GSTATS itself')
 
 end subroutine gstats_labels
-
-!===================================================================================================
-
-subroutine set_ectrans_gpu_nflev(kflev)
-  use ec_env_mod, only : ec_putenv
-  integer(kind=jpim), intent(in) :: kflev
-  character(len=32) :: ECTRANS_GPU_NFLEV
-  write(ECTRANS_GPU_NFLEV,'(A,I0)') "ECTRANS_GPU_NFLEV=",kflev
-  call ec_putenv(ECTRANS_GPU_NFLEV, overwrite=.true.)
-end subroutine
-
 
 end program transform_test
 

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -382,10 +382,6 @@ call setup_trans0(kout=nout, kerr=nerr, kprintlev=merge(2, 0, verbosity == 1), k
 call gstats(1, 1)
 
 call gstats(2, 0)
-! IFS spectral fields are dimensioned NFLEVL, Nils !!
-call set_ectrans_gpu_nflev(nflevl)
-  ! We pass nflevl via environment variable in order not to change API
-  ! In long run, ectrans should grow its internal buffers automatically
 call setup_trans(ksmax=nsmax, kdgl=ndgl, kloen=nloen, ldsplit=.true., lduserpnm=luserpnm, &
   &              lduseflt=luseflt)
 call gstats(2, 1)
@@ -1688,16 +1684,6 @@ subroutine gstats_labels
   call gstats_label(400, '   ', 'GSTATS         - GSTATS itself')
 
 end subroutine gstats_labels
-
-!===================================================================================================
-
-subroutine set_ectrans_gpu_nflev(kflev)
-  use ec_env_mod, only : ec_putenv
-  integer(kind=jpim), intent(in) :: kflev
-  character(len=32) :: ECTRANS_GPU_NFLEV
-  write(ECTRANS_GPU_NFLEV,'(A,I0)') "ECTRANS_GPU_NFLEV=",kflev
-  call ec_putenv(ECTRANS_GPU_NFLEV, overwrite=.true.)
-end subroutine
 
 end program ectrans_benchmark
 


### PR DESCRIPTION
As described in the comment, we pass(ed) `nflevl` via an environment variable so we didn't have to modify the ecTrans API, back when we had to know this in order to allocate GPU device buffers. Now that we do indeed grow those buffers automatically, we don't need this (and indeed this code has been "dead" for over a year now) :)