### PR TITLE
Tidy SUPOLF

### DIFF
--- a/src/trans/common/internal/supolf_mod.F90
+++ b/src/trans/common/internal/supolf_mod.F90
@@ -94,6 +94,10 @@ DDL(K) = REAL(2 * K * (K + 1) - 2 * KM**2 - 1, JPRD) / REAL((2 * K - 1) * (2 * K
 ZEPS  = EPSILON(ZSCALE)
 ICORR3 = 0
 
+! This parameter determines which polynomials are computed
+! ICHEAP = 1 : all polynomials
+! ICHEAP = 2 : only even polynomials
+! ICHEAP = 3 : only odd polynomials
 ICHEAP = 1
 IF (PRESENT(KCHEAP)) THEN
   ICHEAP = KCHEAP


### PR DESCRIPTION
I've started to tidy up and document SUPOLF. This subroutine is used to generate the associated Legendre polynomials at a particular latitude and zonal wavenumber. Documentation here: https://sites.ecmwf.int/docs/ectrans/page/design/legendre_polynomials.html.