### PR TITLE
Allocate variable before subroutine calls

### DIFF
--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -661,10 +661,12 @@ do jstep = 1, iters+iters_warmup
       zgp3a (iend+1:, :, :, ngpblks) = 0
       zgp2 (iend+1:, :, ngpblks) = 0
       write (checksums_filename,'(A)') trim(cchecksums_path)//'_inv_trans.checksums'
+      allocate(ivsetsc(0))
       call dump_checksums(filename = checksums_filename, noutdump=noutdump,                 &
                         & jstep = jstep, myproc = myproc, nproma = nproma, ngptotg=ngptotg, &
                         & ivset = ivset, ivsetsc = ivsetsc, ivsetsc2 = ivsetsc2,            &
                         & nspec2g=nspec2g, zgpuv=zgpuv, zgp3a=zgp3a, zgp2=zgp2)
+      deallocate(ivsetsc)
     endif
   endif
   call gstats(4,1)
@@ -716,11 +718,13 @@ do jstep = 1, iters+iters_warmup
 
     if (ldump_checksums) then
       write (checksums_filename,'(A)') trim(cchecksums_path)//'_dir_trans.checksums'
+      allocate(ivsetsc(0))
       call dump_checksums(filename = checksums_filename, noutdump = noutdump,               &
                         & jstep = jstep, myproc = myproc, nproma = nproma, ngptotg=ngptotg, &
                         & ivset = ivset, ivsetsc = ivsetsc, ivsetsc2 = ivsetsc2,            &
                         & nspec2g=nspec2g, zspvor=zspvor, zspdiv=zspdiv, zspsc3a=zspsc3a,   &
                         & zspsc2=zspsc2)
+      deallocate(ivsetsc)
     endif
 
   endif


### PR DESCRIPTION
While testing ectrans I ran in to runtime failures in some ctests relating to allocatable arrays being passed to dump_checksums when they weren't allocated.

The solution I have implemented here is to allocate them to a zero-sized array, then deallocate them when after the subroutine returns.  This isn't very clean I know.  Is there a better way of fixing this?