### PR TITLE
Initialise pointer in ectrans_memory

### DIFF
--- a/src/programs/util/ectrans_memory.F90
+++ b/src/programs/util/ectrans_memory.F90
@@ -81,7 +81,7 @@ end type
 
 type(allocator_t) :: allocator
 
-character(kind=c_char), pointer, private :: c_label(:)
+character(kind=c_char), pointer, private :: c_label(:) => null()
 
 interface
     function c_allocate_var(bytes) result(ptr) bind(c, name="ectrans_memory_allocate_var")


### PR DESCRIPTION
While testing I ran into failures related to use of an uninitialized pointer c_label.  Actually it was being passed to the associated intrinsic; this is invalid Fortran if the pointer is in an undefined state, as it is at the start.  I have fixed this by initializing it in its declaration.