### PR TITLE
Correct test properties for test with FLT option

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -318,7 +318,7 @@ foreach( benchmark ${benchmarks} )
               MPI ${mpi}
               OMP ${omp}
           )
-          ectrans_set_test_properties( ${base_title}_nfld10_nlev20 )
+          ectrans_set_test_properties( ${base_title}_nfld10_nlev20_flt )
         endif()
       endforeach()
     endforeach()


### PR DESCRIPTION
We weren't setting the properties for the FLT test properly.