### PR TITLE
Update CUFFT error codes

### DIFF
--- a/src/trans/gpu/algor/hicfft_cuda.h
+++ b/src/trans/gpu/algor/hicfft_cuda.h
@@ -118,6 +118,9 @@ inline static const char * _fftGetErrorEnum(cufftResult error)
         case CUFFT_NOT_SUPPORTED:
         return "CUFFT_NOT_SUPPORTED";
 
+// These are only available from 13.0 onwards
+// https://docs.nvidia.com/cuda/archive/12.9.1/cufft/index.html#return-value-cufftresult
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 13000
         case CUFFT_MISSING_DEPENDENCY:
         return "CUFFT_MISSING_DEPENDENCY";
 
@@ -129,6 +132,7 @@ inline static const char * _fftGetErrorEnum(cufftResult error)
 
         case CUFFT_NVSHMEM_FAILURE:
         return "CUFFT_NVSHMEM_FAILURE";
+#endif
 
 // These are deprecated from CUDA 13.0 onwards
 // https://docs.nvidia.com/cuda/cufft/#deprecated-functionality

--- a/src/trans/gpu/algor/hicfft_cuda.h
+++ b/src/trans/gpu/algor/hicfft_cuda.h
@@ -106,14 +106,8 @@ inline static const char * _fftGetErrorEnum(cufftResult error)
         case CUFFT_UNALIGNED_DATA:
         return "CUFFT_UNALIGNED_DATA";
 
-        case CUFFT_INCOMPLETE_PARAMETER_LIST:
-        return "CUFFT_INCOMPLETE_PARAMETER_LIST";
-
         case CUFFT_INVALID_DEVICE:
         return "CUFFT_INVALID_DEVICE";
-
-        case CUFFT_PARSE_ERROR:
-        return "CUFFT_PARSE_ERROR";
 
         case CUFFT_NO_WORKSPACE:
         return "CUFFT_NO_WORKSPACE";

--- a/src/trans/gpu/algor/hicfft_cuda.h
+++ b/src/trans/gpu/algor/hicfft_cuda.h
@@ -129,6 +129,19 @@ inline static const char * _fftGetErrorEnum(cufftResult error)
 
         case CUFFT_NVSHMEM_FAILURE:
         return "CUFFT_NVSHMEM_FAILURE";
+
+// These are deprecated from CUDA 13.0 onwards
+// https://docs.nvidia.com/cuda/cufft/#deprecated-functionality
+#if defined(CUDART_VERSION) && CUDART_VERSION < 13000
+        case CUFFT_INCOMPLETE_PARAMETER_LIST:
+        return "CUFFT_INCOMPLETE_PARAMETER_LIST";
+
+        case CUFFT_PARSE_ERROR:
+        return "CUFFT_PARSE_ERROR";
+
+        case CUFFT_LICENSE_ERROR:
+        return "CUFFT_LICENSE_ERROR";
+#endif
     }
 
     return "<unknown>";

--- a/src/trans/gpu/algor/hicfft_cuda.h
+++ b/src/trans/gpu/algor/hicfft_cuda.h
@@ -117,6 +117,18 @@ inline static const char * _fftGetErrorEnum(cufftResult error)
 
         case CUFFT_NOT_SUPPORTED:
         return "CUFFT_NOT_SUPPORTED";
+
+        case CUFFT_MISSING_DEPENDENCY:
+        return "CUFFT_MISSING_DEPENDENCY";
+
+        case CUFFT_NVRTC_FAILURE:
+        return "CUFFT_NVRTC_FAILURE";
+
+        case CUFFT_NVJITLINK_FAILURE:
+        return "CUFFT_NVJITLINK_FAILURE";
+
+        case CUFFT_NVSHMEM_FAILURE:
+        return "CUFFT_NVSHMEM_FAILURE";
     }
 
     return "<unknown>";


### PR DESCRIPTION
Quoting Nvidia docs (https://docs.nvidia.com/cuda/cufft/):

Starting from CUDA 13.0:

The following error codes have been removed:
CUFFT_INCOMPLETE_PARAMETER_LIST, CUFFT_PARSE_ERROR, CUFFT_LICENSE_ERROR.

Starting from CUDA 12.9:

The following error codes are deprecated and will be removed in a future release: CUFFT_INCOMPLETE_PARAMETER_LIST, CUFFT_PARSE_ERROR, CUFFT_LICENSE_ERROR.