### PR TITLE
Fix gath spec bug

### DIFF
--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -1613,6 +1613,7 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
     &            pspec=zspvor)
   if (myproc == 1) then
+    icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspvor", icrc
   endif
@@ -1620,6 +1621,7 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
     &            pspec=zspdiv)
   if (myproc == 1) then
+    icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspdiv", icrc
   endif
@@ -1628,6 +1630,7 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
     &            kvset=ivsetsc, pspec=zspscalar)
   if (myproc == 1) then
+    icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspscalar", icrc
   endif
@@ -1671,6 +1674,7 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
     &            pspec=zspvor)
   if (myproc == 1) then
+    icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspvor", icrc
   endif
@@ -1678,6 +1682,7 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
     &            pspec=zspdiv)
   if (myproc == 1) then
+    icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspdiv", icrc
   endif
@@ -1686,6 +1691,7 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
       &            pspec=zspsc3a(:,:,jfld))
     if (myproc == 1) then
+      icrc = 0
       call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
       write(noutdump, '(a,"(",i0,") = ",z16.16)') "zspsc3a", jfld, icrc
     endif
@@ -1693,6 +1699,7 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
 
   call gath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc2, pspec=zspsc2)
   if (myproc == 1) then
+    icrc = 0
     call crc64(gspfld(1,:), int(size(gspfld(1,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspsc2", icrc
   endif

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -1600,45 +1600,37 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   real(kind=jprb), intent(in) :: zspvor(:,:)
   real(kind=jprb), intent(in) :: zspdiv(:,:)
   real(kind=jprb), intent(in) :: zspscalar(:,:)
+  integer(kind=jpim) :: numfld
   integer(kind=jpib) :: icrc
-  integer(kind=jpim) :: jfld
   real(kind=jprb), allocatable :: gspfld(:,:)
 
   if (myproc == 1) then
     call open_dump_checksums_file(filename, noutdump, jstep)
-    allocate(gspfld(1,nspec2g))
+    allocate(gspfld(max(size(ivset), size(ivsetsc)), nspec2g))
   endif
 
-  icrc = 0
-  do jfld = 1, size(ivset, 1)
-    call gath_spec(pspecg=gspfld, kfgathg=1, kto=(/1/), kvset=ivset(jfld:jfld), kresol=1, &
-      &            pspec=zspvor(jfld:jfld,:))
-    if (myproc == 1) then
-      call crc64(gspfld(:,:), int(size(gspfld(:,:)) * kind(gspfld), 8), icrc)
-      write(noutdump, '(a," (",i0,") = ",z16.16)') "zspvor", jfld, icrc
-    endif
-  enddo
+  numfld = size(ivset)
+  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
+    &            pspec=zspvor)
+  if (myproc == 1) then
+    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
+    write(noutdump, '(a," = ",z16.16)') "zspvor", icrc
+  endif
 
-  icrc = 0
-  do jfld = 1, size(ivset, 1)
-    call gath_spec(pspecg=gspfld, kfgathg=1, kto=(/1/), kvset=ivset(jfld:jfld), kresol=1, &
-      &            pspec=zspdiv(jfld:jfld,:))
-    if (myproc == 1) then
-      call crc64(gspfld(:,:), int(size(gspfld(:,:)) * kind(gspfld), 8), icrc)
-      write(noutdump, '(a," (",i0,") = ",z16.16)') "zspdiv", jfld, icrc
-    endif
-  enddo
+  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
+    &            pspec=zspdiv)
+  if (myproc == 1) then
+    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
+    write(noutdump, '(a," = ",z16.16)') "zspdiv", icrc
+  endif
 
-  icrc = 0
-  do jfld = 1, size(ivsetsc, 1)
-    call gath_spec(pspecg=gspfld, kfgathg=1, kto=(/1/), kvset=ivsetsc(jfld:jfld), kresol=1, &
-      &            pspec=zspscalar(jfld:jfld,:))
-    if (myproc == 1) then
-      call crc64(gspfld(:,:), int(size(gspfld(:,:)) * kind(gspfld), 8), icrc)
-      write(noutdump, '(a," (",i0,") = ",z16.16)') "zspscalar", jfld, icrc
-    endif
-  enddo
-
+  numfld = size(ivsetsc)
+  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
+    &            kvset=ivsetsc, pspec=zspscalar)
+  if (myproc == 1) then
+    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
+    write(noutdump, '(a," = ",z16.16)') "zspscalar", icrc
+  endif
 
   if (myproc == 1) then
     write(nout,*) "close ", noutdump
@@ -1666,56 +1658,44 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   real(kind=jprb), intent(in), optional :: zspdiv(:,:)
   real(kind=jprb), intent(in), optional :: zspsc3a(:,:,:)
   real(kind=jprb), intent(in), optional :: zspsc2(:,:)
+  integer(kind=jpim) :: numfld, jfld
   integer(kind=jpib) :: icrc
-  integer(kind=jpim) :: jlev, jfld
   real(kind=jprb), allocatable :: gspfld(:,:)
 
   if (myproc == 1) then
     call open_dump_checksums_file(filename, noutdump, jstep)
-    allocate(gspfld(1,nspec2g))
+    allocate(gspfld(max(size(ivset), 1), nspec2g)) ! size(ivsetsc2) is always 1
   endif
 
-  icrc = 0
-  do jfld = 1, size(ivset, 1)
-    call gath_spec(pspecg=gspfld, kfgathg=1, kto=(/1/), kvset=ivset(jfld:jfld), kresol=1, &
-      &            pspec=zspvor(jfld:jfld,:))
+  numfld = size(ivset)
+  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
+    &            pspec=zspvor)
+  if (myproc == 1) then
+    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
+    write(noutdump, '(a," = ",z16.16)') "zspvor", icrc
+  endif
+
+  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
+    &            pspec=zspdiv)
+  if (myproc == 1) then
+    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
+    write(noutdump, '(a," = ",z16.16)') "zspdiv", icrc
+  endif
+
+  do jfld = 1, size(zspsc3a, 3)
+    call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
+      &            pspec=zspsc3a(:,:,jfld))
     if (myproc == 1) then
-      call crc64(gspfld(:,:), int(size(gspfld(:,:)) * kind(gspfld), 8), icrc)
-      write(noutdump, '(a," (",i0,") = ",z16.16)') "zspvor", jfld, icrc
+      call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
+      write(noutdump, '(a,"(",i0,") = ",z16.16)') "zspsc3a", jfld, icrc
     endif
   enddo
 
-  icrc = 0
-  do jfld = 1, size(ivset, 1)
-    call gath_spec(pspecg=gspfld, kfgathg=1, kto=(/1/), kvset=ivset(jfld:jfld), kresol=1, &
-      &            pspec=zspdiv(jfld:jfld,:))
-    if (myproc == 1) then
-      call crc64(gspfld(:,:), int(size(gspfld(:,:)) * kind(gspfld), 8), icrc)
-      write(noutdump, '(a," (",i0,") = ",z16.16)') "zspdiv", jfld, icrc
-    endif
-  enddo
-
-  icrc = 0
-   do jfld = 1, size(zspsc3a, 3)
-     do jlev = 1, size(ivset, 1)
-       call gath_spec(pspecg=gspfld, kfgathg=1, kto=(/1/), kvset=ivset(jlev:jlev), &
-         &            kresol=1, pspec=zspsc3a(jlev:jlev,:,jfld))
-       if (myproc == 1) then
-         call crc64(gspfld(:,:), int(size(gspfld(:,:)) * kind(gspfld), 8), icrc)
-         write(noutdump, '(a," (",i0,", ",i0,") = ",z16.16)') "zspsc3a", jlev, jfld, icrc
-       endif
-     enddo
-   enddo
-
-   icrc = 0
-   do jfld = 1, size(ivsetsc2, 1)
-     call gath_spec(pspecg=gspfld, kfgathg=1, kto=(/1/), kvset=ivsetsc2(jfld:jfld), kresol=1, &
-       &            pspec=zspsc2(jfld:jfld,:))
-     if (myproc == 1) then
-       call crc64(gspfld(:,:), int(size(gspfld(:,:)) * kind(gspfld), 8), icrc)
-       write(noutdump, '(a," (",i0,") = ",z16.16)') "zspsc2", jfld, icrc
-     endif
-   enddo
+  call gath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc2, pspec=zspsc2)
+  if (myproc == 1) then
+    call crc64(gspfld(1,:), int(size(gspfld(1,:)) * kind(gspfld), 8), icrc)
+    write(noutdump, '(a," = ",z16.16)') "zspsc2", icrc
+  endif
 
   if (myproc == 1) then
     write(nout,*) "close ", noutdump

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -1610,29 +1610,35 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   endif
 
   numfld = size(ivset)
-  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
-    &            pspec=zspvor)
   if (myproc == 1) then
+    call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
+      &            kvset=ivset, pspec=zspvor)
     icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspvor", icrc
+  else
+    call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspvor)
   endif
 
-  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
-    &            pspec=zspdiv)
   if (myproc == 1) then
+    call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
+      &            kvset=ivset, pspec=zspdiv)
     icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspdiv", icrc
+  else
+    call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspdiv)
   endif
 
   numfld = size(ivsetsc)
-  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
-    &            kvset=ivsetsc, pspec=zspscalar)
   if (myproc == 1) then
+    call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
+      &            kvset=ivsetsc, pspec=zspscalar)
     icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspscalar", icrc
+  else
+    call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivsetsc, pspec=zspscalar)
   endif
 
   if (myproc == 1) then
@@ -1671,37 +1677,45 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   endif
 
   numfld = size(ivset)
-  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
-    &            pspec=zspvor)
   if (myproc == 1) then
+    call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
+      &            kvset=ivset, pspec=zspvor)
     icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspvor", icrc
+  else
+    call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspvor)
   endif
 
-  call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
-    &            pspec=zspdiv)
   if (myproc == 1) then
+    call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
+      &            kvset=ivset, pspec=zspdiv)
     icrc = 0
     call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspdiv", icrc
+  else
+    call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspdiv)
   endif
 
   do jfld = 1, size(zspsc3a, 3)
-    call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, &
-      &            pspec=zspsc3a(:,:,jfld))
     if (myproc == 1) then
+      call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
+        &            kvset=ivset, pspec=zspsc3a(:,:,jfld))
       icrc = 0
       call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
       write(noutdump, '(a,"(",i0,") = ",z16.16)') "zspsc3a", jfld, icrc
+    else
+      call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspsc3a(:,:,jfld))
     endif
   enddo
 
-  call gath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc2, pspec=zspsc2)
   if (myproc == 1) then
+    call gath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc2, pspec=zspsc2)
     icrc = 0
     call crc64(gspfld(1,:), int(size(gspfld(1,:)) * kind(gspfld), 8), icrc)
     write(noutdump, '(a," = ",z16.16)') "zspsc2", icrc
+  else
+    call gath_spec(kfgathg=1, kto=[1], kvset=ivsetsc2, pspec=zspsc2)
   endif
 
   if (myproc == 1) then

--- a/src/programs/ectrans-lam-benchmark.F90
+++ b/src/programs/ectrans-lam-benchmark.F90
@@ -1615,22 +1615,26 @@ subroutine dump_checksums(filename, noutdump, &
   if (present(sp3d)) then
     numfld = size(ivset)
     do jfld = 1, size (sp3d, 3)
-      call egath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
-        &             kvset=ivset, pspec=sp3d(:,:,jfld))
       if (myproc == 1) then
+        call egath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
+          &             kvset=ivset, pspec=sp3d(:,:,jfld))
         icrc = 0
         call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
         write(noutdump, '(a,"(",i0,") = ",z16.16)') "sp3d", jfld, icrc
+      else
+        call egath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=sp3d(:,:,jfld))
       endif
     enddo
   endif
 
   if (present(zspc2)) then
-    call egath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc, pspec=zspc2)
     if (myproc == 1) then
+      call egath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc, pspec=zspc2)
       icrc = 0
       call crc64(gspfld(1,:), int(size(gspfld(1,:)) * kind(gspfld), 8), icrc)
       write (noutdump, '(a," = ",z16.16)') "zspc2", icrc
+    else
+      call egath_spec(kfgathg=1, kto=[1], kvset=ivsetsc, pspec=zspc2)
     endif
   endif
 

--- a/src/programs/ectrans-lam-benchmark.F90
+++ b/src/programs/ectrans-lam-benchmark.F90
@@ -1554,7 +1554,7 @@ subroutine dump_checksums(filename, noutdump, &
   real(kind=jprb), intent(in), optional :: zspc2 (:,:)
 
   integer(kind=jpib) :: icrc
-  integer(kind=jpim) :: jlev, jfld
+  integer(kind=jpim) :: jlev, jfld, numfld
   real(kind=jprb), allocatable :: gfld(:,:)
   real(kind=jprb), allocatable :: gspfld(:,:)
   logical :: exist = .false.
@@ -1572,7 +1572,7 @@ subroutine dump_checksums(filename, noutdump, &
     write(noutdump,*) "===================="
 
     if (present(zgpuv) .or. present(zgp3a) .or. present(zgp2))  allocate(gfld(ngptotg,1))
-    if (present(sp3d) .or. present(zspc2))  allocate(gspfld(1,nspec2g))
+    if (present(sp3d) .or. present(zspc2))  allocate(gspfld(max(size(ivset), 1), nspec2g))
 
   endif
 
@@ -1613,28 +1613,25 @@ subroutine dump_checksums(filename, noutdump, &
     enddo
   endif
   if (present(sp3d)) then
-    icrc = 0
+    numfld = size(ivset)
     do jfld = 1, size (sp3d, 3)
-      do jlev = 1, size (sp3d, 1)
-        call egath_spec(pspecg=gspfld,kfgathg=1,kto=(/1/),kvset=ivset(jlev:jlev),kresol=1,pspec=sp3d(jlev:jlev,:,jfld))
-        if (myproc == 1) then
-          call crc64 (gspfld (:, :), int (size (gspfld (:, :)) * kind (gspfld), 8), icrc)
-          write (noutdump, '(a," (",i0,", ",i0,") = ",z16.16)') "sp3d", jlev, jfld, icrc
-        endif
-      enddo
+      call egath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
+        &             kvset=ivset, pspec=sp3d(:,:,jfld))
+      if (myproc == 1) then
+        icrc = 0
+        call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
+        write(noutdump, '(a,"(",i0,") = ",z16.16)') "sp3d", jfld, icrc
+      endif
     enddo
   endif
 
   if (present(zspc2)) then
-    icrc = 0
-
-    do jfld = 1, size (zspc2, 1)
-      call egath_spec(pspecg=gspfld,kfgathg=1,kto=(/1/),kvset=ivsetsc(1:1), kresol=1,pspec=zspc2(jfld:jfld,:))
-      if (myproc == 1) then
-        call crc64 (gspfld (:, :), int (size (gspfld (:, :)) * kind (gspfld), 8), icrc)
-        write (noutdump, '(a," (",i0,") = ",z16.16)') "zspc2", jfld, icrc
-      endif
-    enddo
+    call egath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc, pspec=zspc2)
+    if (myproc == 1) then
+      icrc = 0
+      call crc64(gspfld(1,:), int(size(gspfld(1,:)) * kind(gspfld), 8), icrc)
+      write (noutdump, '(a," = ",z16.16)') "zspc2", icrc
+    endif
   endif
 
   if (myproc == 1) then


### PR DESCRIPTION
As mentioned in https://github.com/ecmwf-ifs/ectrans/pull/339, there is a bug in the way we call `gath_spec` in the benchmark program, when checksums are dumped. The checksum is computed per global level, but spectral arrays are decomposed in the levels dimension, so this doesn't make sense. This bug leads to spurious checksum differences between benchmark runs with different `NPRTRV` values.

This PR fixes the bug and permits us to include `NPRTRV /= 1` cases in the test suite. I've included several modifications to the test suite and necessary changes to the CI to ensure reproducibility with these changes.