### PR TITLE
Add missing linker language to generate_api_test_suite

### DIFF
--- a/tests/trans/api/CMakeLists.txt
+++ b/tests/trans/api/CMakeLists.txt
@@ -59,6 +59,7 @@ function( generate_api_test_suite )
                                 ${suite_name}${suffix}.c
                                 ${suite_name}.F90
                                 ${CMAKE_CURRENT_SOURCE_DIR}/../util.F90
+                            LINKER_LANGUAGE Fortran
                             LIBS ${libs} )
 
     # Prevent the Fortran runtime from trying to provide a main program


### PR DESCRIPTION
A small fix to `generate_api_test_suite` to restore the ability to link ectrans statically in IFS builds.