### PR TITLE
Ensure trans_set_mpi_comm compatibility with congruent comms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ ecbuild_enable_fortran( REQUIRED NO_MODULE_DIRECTORY )
 
 ### Find (optional) dependencies
 
-ecbuild_find_package( NAME fiat REQUIRED )
+ecbuild_find_package( NAME fiat VERSION 1.3.0 REQUIRED )
 
 # Inherit MPI feature from FIAT (if you don't want MPI, rebuild FIAT with ENABLE_MPI=OFF)
 set( HAVE_MPI ${fiat_HAVE_MPI} )

--- a/src/transi/transi_module.F90
+++ b/src/transi/transi_module.F90
@@ -46,7 +46,8 @@ use MPL_module, only: &
   MPL_SETDFLT_COMM, &
   MPL_COMM_OML, &
   LMPLUSERCOMM, &
-  MPLUSERCOMM
+  MPLUSERCOMM, &
+  MPL_COMM_COMPARE
 
 use MPL_DATA_MODULE, only: &
   MPL_NUMPROC
@@ -658,6 +659,7 @@ function trans_set_mpi_comm(mpi_user_comm) bind(C,name="trans_set_mpi_comm") res
   integer(c_int), value, intent(in) :: mpi_user_comm
 
   integer :: dummy_comm
+  integer(c_int) :: MPL_COMM_COMPARE_RESULT, MPL_COMM_COMPARE_ERROR
 
   iret = TRANS_SUCCESS
   if (.not. USE_MPI) return
@@ -687,8 +689,15 @@ function trans_set_mpi_comm(mpi_user_comm) bind(C,name="trans_set_mpi_comm") res
       return
     end if
 
-    if (mpi_user_comm /= MPL_COMM_OML(OML_MY_THREAD())) then
-      write(error_unit,'(A)') "trans_set_mpi_comm: ERROR: Must be called prior to trans_init."
+    CALL MPL_COMM_COMPARE(mpi_user_comm, MPL_COMM_OML(OML_MY_THREAD()), MPL_COMM_COMPARE_RESULT, MPL_COMM_COMPARE_ERROR)
+    IF (MPL_COMM_COMPARE_ERROR /= 0 .OR. MPL_COMM_COMPARE_RESULT > 1) THEN
+      ! The communicators are not identical (MPL_COMM_COMPARE_RESULT=0) and not congruent (MPL_COMM_COMPARE_RESULT=1)
+      write(error_unit,'(A)') "trans_set_mpi_comm: ERROR:&
+          & trans_set_mpi_comm must be called prior to trans_init."
+      write(error_unit,'(A,I0,A)') "                          &
+          & Previously initialised with a different MPI communicator (",MPL_COMM_OML(OML_MY_THREAD()),")"
+      write(error_unit,'(A,I0,A)') "                          &
+          & Changing the communicator mid-run to a non-congruent one (",mpi_user_comm,") is not supported."
       iret = TRANS_ERROR
       return
     end if


### PR DESCRIPTION
This PR fixes an issue of compatibility with using `trans_set_mpi_comm` with where the same comm as was already set-up before is set up. This is detected and then `trans_set_mpi_comm` is supposed to be a no-op.
It is possible these comms are however not detected correctly to be the same:

Typically with MPL_INIT the communicator used is `MPL_COMM_OML(1)`, created with `MPL_CREATE_LOCOMM`.
When created with `MPI_COMM_WORLD` argument, then ` MPL_COMM_OML(1)`  is a communicator which is by default **congruent** with MPI_COMM_WORLD but not necessarily the same.
The value returned by MPL_COMM_OML(1) is 3, whereas MPI_COMM_WORLD = 0.

NB. : Congruent means the same processes and same order, but not identical context. Messages sent cannot be exchanged between congruent communicators.

This is needed to avoid changing API in https://github.com/ecmwf/atlas/pull/346