### PR TITLE
Fix ectrans_test_install with static builds of fiat and ectrans

### DIFF
--- a/cmake/ectrans-import.cmake.in
+++ b/cmake/ectrans-import.cmake.in
@@ -47,11 +47,14 @@ endif()
 ##################################################################
 ## Export project dependencies
 
-include( CMakeFindDependencyMacro )
-if( ectrans_REQUIRES_PRIVATE_DEPENDENCIES OR CMAKE_Fortran_COMPILER_LOADED )
-    if( NOT CMAKE_Fortran_COMPILER_LOADED )
-        enable_language( Fortran )
-    endif()
+if( ectrans_REQUIRES_PRIVATE_DEPENDENCIES )
+    foreach( lang C CXX Fortran )
+        if (NOT CMAKE_${lang}_COMPILER_LOADED)
+            enable_language( ${lang} )
+        endif()
+    endforeach()
+
+    include( CMakeFindDependencyMacro )
     if( trans_HAVE_OMP AND NOT TARGET OpenMP::OpenMP_Fortran )
         find_dependency( OpenMP COMPONENTS Fortran )
     endif()

--- a/cmake/ectrans-import.cmake.in
+++ b/cmake/ectrans-import.cmake.in
@@ -47,14 +47,14 @@ endif()
 ##################################################################
 ## Export project dependencies
 
-if( ectrans_REQUIRES_PRIVATE_DEPENDENCIES )
+include( CMakeFindDependencyMacro )
+if( ectrans_REQUIRES_PRIVATE_DEPENDENCIES OR CMAKE_Fortran_COMPILER_LOADED )
     foreach( lang C CXX Fortran )
         if (NOT CMAKE_${lang}_COMPILER_LOADED)
             enable_language( ${lang} )
         endif()
     endforeach()
 
-    include( CMakeFindDependencyMacro )
     if( trans_HAVE_OMP AND NOT TARGET OpenMP::OpenMP_Fortran )
         find_dependency( OpenMP COMPONENTS Fortran )
     endif()

--- a/tests/test-install.sh.in
+++ b/tests/test-install.sh.in
@@ -47,7 +47,7 @@ cmake $SOURCE \
   -DECBUILD_2_COMPAT=OFF \
   "$@"
 
-cmake --build .
+cmake --build . --verbose --parallel 1
 
 # For some reason these compilers are more stack hungry
 if [[ "@CMAKE_Fortran_COMPILER_ID@" = "LLVMFlang" || \

--- a/tests/test_install/CMakeLists.txt
+++ b/tests/test_install/CMakeLists.txt
@@ -6,7 +6,7 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-cmake_minimum_required( VERSION 3.12 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.18 FATAL_ERROR )
 project( ectrans_test_install VERSION 0.0.0 LANGUAGES Fortran )
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)


### PR DESCRIPTION
When using a fiat static build, and a static build of ectrans, the test `ectrans_test_install` is failing:
```
+ cmake --build .
1: [ 12%] Building Fortran object CMakeFiles/main_dp.dir/main.F90.o
1: [ 25%] Linking Fortran executable bin/main_dp
1: [ 25%] Built target main_dp
1: [ 37%] Building Fortran object CMakeFiles/main_sp.dir/main.F90.o
1: [ 50%] Linking Fortran executable bin/main_sp
1: [ 50%] Built target main_sp
1: [ 62%] Building C object CMakeFiles/transi_sptogp.dir/transi_sptogp.c.o
1: [ 75%] Linking C executable bin/transi_sptogp
1: Undefined symbols for architecture arm64:
1:   "___cxa_demangle", referenced from:
1:       _cxxdemangle in libfiat.a[56](cxxdemangle.cc.o)
1: ld: symbol(s) not found for architecture arm64
1: clang: error: linker command failed with exit code 1 (use -v to see invocation)
1: make[2]: *** [bin/transi_sptogp] Error 1
1: make[1]: *** [CMakeFiles/transi_sptogp.dir/all] Error 2
1: make: *** [all] Error 2
```
This symbol is in the fiat TARGET which has the property
```IMPORTED_LINK_INTERFACE_LANGUAGES_RELWITHDEBINFO "C;CXX;Fortran"```
The CXX linking part gets ignored because the test project `ectrans_test_install` does not have CXX enabled as a language either via `project()` or via `enable_language`.

A fix in ectrans-import.cmake is proposed here which enables languages C CXX Fortran in the case where ectrans is compiled as static library.