### PR TITLE
Refactor compare_checksums.py

### DIFF
--- a/tests/compare_checksums.py
+++ b/tests/compare_checksums.py
@@ -9,10 +9,10 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-import sys
 import os
 import filecmp
 from glob import glob
+import argparse
 
 class colors:
     SUCCESS = '\033[94m'
@@ -75,14 +75,17 @@ def compare_checksums(folder_path, ntasks, nthreads):
     return error_count == 0
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        print("Usage: python compare_checksums.py <folder_path> <ntasks list> <nthreads list>")
-        exit(1)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("folder_path", help="Path to the folder containing checksum files")
+    parser.add_argument("ntasks", help="Comma-separated list of ntasks values to compare (e.g., '1,2,4')")
+    parser.add_argument("nthreads", help="Comma-separated list of nthreads values to compare (e.g., '1,2,4')")
+    args = parser.parse_args()
+
+    folder = args.folder_path
+    ntasks = args.ntasks.split(",")
+    nthreads = args.nthreads.split(",")
+
+    if compare_checksums(folder, ntasks, nthreads):
+        exit(0)
     else:
-        folder = sys.argv[1]
-        ntasks = sys.argv[2].split(",")
-        nthreads = sys.argv[3].split(",")
-        if compare_checksums(folder, ntasks, nthreads):
-            exit(0)
-        else:
-            exit(1)
+        exit(1)

--- a/tests/compare_checksums.py
+++ b/tests/compare_checksums.py
@@ -34,6 +34,7 @@ def compare_checksums(folder_path, ntasks, nthreads, exclude=""):
     # Build list of all mpi0_omp1 checksum files
     reference_files = glob(os.path.join(folder_path, "*mpi0_omp1*.checksums"))
     if exclude:
+        print(f"Excluding tests that match \"{exclude}\"")
         reference_files = [f for f in reference_files if exclude not in f]
     if len(reference_files) == 0:
         print("No reference checksum files found (mpi0_omp1)")

--- a/tests/compare_checksums.py
+++ b/tests/compare_checksums.py
@@ -19,7 +19,7 @@ class colors:
     FAILURE = '\033[91m'
     ENDC = '\033[0m'
 
-def compare_checksums(folder_path, ntasks, nthreads):
+def compare_checksums(folder_path, ntasks, nthreads, exclude=""):
     if not os.path.isdir(folder_path):
         print(f"Error: '{folder_path}' is not a valid directory.")
         return False
@@ -33,6 +33,8 @@ def compare_checksums(folder_path, ntasks, nthreads):
 
     # Build list of all mpi0_omp1 checksum files
     reference_files = glob(os.path.join(folder_path, "*mpi0_omp1*.checksums"))
+    if exclude:
+        reference_files = [f for f in reference_files if exclude not in f]
     if len(reference_files) == 0:
         print("No reference checksum files found (mpi0_omp1)")
         return False
@@ -79,13 +81,15 @@ if __name__ == "__main__":
     parser.add_argument("folder_path", help="Path to the folder containing checksum files")
     parser.add_argument("ntasks", help="Comma-separated list of ntasks values to compare (e.g., '1,2,4')")
     parser.add_argument("nthreads", help="Comma-separated list of nthreads values to compare (e.g., '1,2,4')")
+    parser.add_argument("-E", "--exclude", help="Pattern to exclude from comparison (e.g., gpu)", default="")
     args = parser.parse_args()
 
     folder = args.folder_path
     ntasks = args.ntasks.split(",")
     nthreads = args.nthreads.split(",")
+    exclude = args.exclude
 
-    if compare_checksums(folder, ntasks, nthreads):
+    if compare_checksums(folder, ntasks, nthreads, exclude=exclude):
         exit(0)
     else:
         exit(1)

--- a/tests/compare_checksums.py
+++ b/tests/compare_checksums.py
@@ -65,7 +65,7 @@ def compare_checksums(folder_path, ntasks, nthreads, exclude=""):
                 return False
     percentage = int(100.0 * (success_count / total_count))
     if error_count > 0:
-        print(f"{percentage}% comparison passed, {colors.FAILURE}{error_count} comparisons failed out of "
+        print(f"{percentage}% comparisons passed, {colors.FAILURE}{error_count} comparisons failed out of "
               f"{total_count}{colors.ENDC}")
 
         print("The following checksum files do not match their mpi0_omp1 references:")

--- a/tests/compare_checksums.py
+++ b/tests/compare_checksums.py
@@ -1,8 +1,19 @@
 #!/usr/bin/env python3
 
+# (C) Copyright 2026- ECMWF.
+# (C) Copyright 2026- RMI.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
 import sys
 import os
 import filecmp
+from glob import glob
+
 class colors:
     SUCCESS = '\033[94m'
     FAILURE = '\033[91m'
@@ -19,45 +30,49 @@ def compare_checksums(folder_path, ntasks, nthreads):
     error_count = 0
     total_count = 0
     failed_list = []
-    for file_name in os.listdir(folder_path):
-        if (".checksums" in file_name and "benchmark" in file_name  and "mpi0_omp1" in file_name):
-            file_path = os.path.join(folder_path, file_name)
-            if os.path.isfile(file_path):
-                print(f"{file_name}")
-                found = False
-                for mpi in ntasks:
-                    for omp in nthreads:
-                        other_file_name = file_name.replace("mpi0_omp1",f"mpi{mpi}_omp{omp}")
-                        if other_file_name == file_name:
-                            continue
-                        other_file_path = os.path.join(folder_path, other_file_name)
-                        if os.path.isfile(other_file_path):
-                            total_count = total_count + 1
-                            found = True
-                            if (filecmp.cmp(file_path, other_file_path)):
-                                print(f"    {other_file_name} ...{colors.SUCCESS}Passed{colors.ENDC}")
-                                success_count = success_count +1
-                            else:
-                                print(f"    {other_file_name} ...***{colors.FAILURE}Failed{colors.ENDC}")
-                                error_count = error_count + 1
-                                failed_list.append(f"{file_path} {other_file_path}")
-                if (not found):
-                    print(f"    No comparison found")
-                    return False
-    percentage = int(100*(success_count/total_count))
-    if (error_count> 0):
-        print(f"{percentage}% comparison passed, {colors.FAILURE}{error_count} comparison failed out of {total_count}{colors.ENDC}")
 
-        print("The following comparisons FAILED:")
+    # Build list of all mpi0_omp1 checksum files
+    reference_files = glob(os.path.join(folder_path, "*mpi0_omp1*.checksums"))
+    if len(reference_files) == 0:
+        print("No reference checksum files found (mpi0_omp1)")
+        return False
 
-        for failed in failed_list:
-            print(f"    {colors.FAILURE}{failed}{colors.ENDC}")
+    # Search through all mpi0_omp1 reference checksum files
+    for file_name in reference_files:
+        if os.path.isfile(file_name):
+            print(f"{file_name}")
+            found = False
+            for mpi in ntasks:
+                for omp in nthreads:
+                    other_file_name = file_name.replace("mpi0_omp1", f"mpi{mpi}_omp{omp}")
+                    if other_file_name == file_name:
+                        continue
+                    if os.path.isfile(other_file_name):
+                        total_count += 1
+                        found = True
+                        if (filecmp.cmp(file_name, other_file_name)):
+                            print(f"    {other_file_name} ...{colors.SUCCESS}Passed{colors.ENDC}")
+                            success_count += 1
+                        else:
+                            print(f"    {other_file_name} ...***{colors.FAILURE}Failed{colors.ENDC}")
+                            error_count += 1
+                            failed_list.append((file_name, other_file_name))
+            if not found:
+                print("No comparison found")
+                return False
+    percentage = int(100.0 * (success_count / total_count))
+    if error_count > 0:
+        print(f"{percentage}% comparison passed, {colors.FAILURE}{error_count} comparisons failed out of "
+              f"{total_count}{colors.ENDC}")
+
+        print("The following checksum files do not match their mpi0_omp1 references:")
+
+        for _, failed in failed_list:
+            print(f"{colors.FAILURE}{failed}{colors.ENDC}")
     else:
         print(f"{percentage}% checks passed")
 
-    if (error_count > 0):
-        return False
-    return True
+    return error_count == 0
 
 if __name__ == "__main__":
     if len(sys.argv) != 4:


### PR DESCRIPTION
I made a few changes to compare_checksums.py:
- Added license header
- Used `glob` to combine a `for` and an `if`
- Some minor Pythonesque style tweaks
- Added check for when no files at all are present
- **Simplified printing of failed tests.** Previously the reference checksum and the failing checksum were printed together which resulted in a very long line that I was finding it hard to read quickly both in the action logs and a text editor. I've removed the first string so only the failing checksum is printed. This is the real reason I opened this PR, the other things are just minor tweaks.