### PR TITLE
missing routine (horiz_field) in precision renamings

### DIFF
--- a/src/etrans/sedrenames.txt
+++ b/src/etrans/sedrenames.txt
@@ -44,6 +44,8 @@ s/egpnorm_trans( *($|\(| |\*))/egpnorm_trans_VARIANTDESIGNATOR\1/g
 s/EGPNORM_TRANS( *($|\(| |\*))/EGPNORM_TRANS_VARIANTDESIGNATOR\1/g
 s/gpnorm_trans( *($|\(| |\*))/gpnorm_trans_VARIANTDESIGNATOR\1/g
 s/GPNORM_TRANS( *($|\(| |\*))/GPNORM_TRANS_VARIANTDESIGNATOR\1/g
+s/horiz_field( *($|\(| |\*))/horiz_field_VARIANTDESIGNATOR\1/g
+s/HORIZ_FIELD( *($|\(| |\*))/HORIZ_FIELD_VARIANTDESIGNATOR\1/g
 s/EINV_TRANS_CTL_MOD/EINV_TRANS_CTL_MOD_VARIANTDESIGNATOR/g
 s/EINV_TRANS_CTLAD_MOD/EINV_TRANS_CTLAD_MOD_VARIANTDESIGNATOR/g
 s/einv_trans( *($|\(| |\*))/einv_trans_VARIANTDESIGNATOR\1/g


### PR DESCRIPTION
Thanks @RyadElKhatibMF for spotting the miss
(cherry picked from commit 7318ac83492181daec9ec5aa87d4a01a55531bc3)