### PR TITLE
Fix CI for intel-classic by removing ambiguity with mpi installations

### DIFF
--- a/.github/tools/install-mpi.sh
+++ b/.github/tools/install-mpi.sh
@@ -35,7 +35,7 @@ while [ $# != 0 ]; do
 done
 
 os=$(uname)
-OMPIVER=4.1.1
+OMPIVER=5.0.7
 MPICHVER=3.4.2
 
 if [ ! -z ${mpi_version+x} ]; then
@@ -62,6 +62,9 @@ case "$os" in
             openmpi)
                 brew ls --versions openmpi || brew install openmpi
                 echo "localhost slots=72" >> $(brew --prefix)/etc/openmpi-default-hostfile
+                echo "localhost slots=72" >> $(brew --prefix)/etc/prte-default-hostfile
+                echo "rmaps_default_mapping_policy=:oversubscribe" >> $(brew --prefix)/etc/prte-mca-params.conf
+
                 # workaround for open-mpi/omp#7516
                 echo "setting the mca gds to hash..."
                 echo "gds = hash" >> $(brew --prefix)/etc/pmix-mca-params.conf
@@ -123,7 +126,8 @@ case "$os" in
                   echo "libmpi.so found -- nothing to build."
                 else
                   echo "Downloading openmpi source..."
-                  wget --no-check-certificate https://www.open-mpi.org/software/ompi/v4.1/downloads/openmpi-$OMPIVER.tar.gz
+                  OMPI_MAJOR_MINOR=$(echo $OMPIVER | sed 's/\([0-9]*\.[0-9]*\).*/\1/')
+                  wget --no-check-certificate https://www.open-mpi.org/software/ompi/v${OMPI_MAJOR_MINOR}/downloads/openmpi-$OMPIVER.tar.gz
                   tar -zxf openmpi-$OMPIVER.tar.gz
                   rm openmpi-$OMPIVER.tar.gz
                   echo "Configuring and building openmpi..."
@@ -133,6 +137,7 @@ case "$os" in
                   ${SCRIPTDIR}/reduce-output.sh make install
                   MPI_INSTALLED=true
                   echo "localhost slots=72" >> ${PREFIX}/etc/openmpi-default-hostfile
+                  echo "rmaps_default_mapping_policy=:oversubscribe" >> ${PREFIX}/etc/prte-mca-params.conf
                   cd -
                   rm -rf openmpi-$OMPIVER
                 fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,8 +174,7 @@ jobs:
         sudo apt-get update
          sudo apt-get install \
           intel-oneapi-compiler-fortran-$version \
-          intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-$version \
-          intel-oneapi-mpi-devel-2021.10.0
+          intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic-$version
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
         echo "CACHE_SUFFIX=$CC-$($CC -dumpversion)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
             compiler_cc: nvc
             compiler_cxx: nvc++
             compiler_fc: nvfortran
-            cmake_options: -DCMAKE_CXX_FLAGS=--diag_suppress177 -DMPI_ARGS=--oversubscribe -DBLA_VENDOR=Generic
+            cmake_options: -DCMAKE_CXX_FLAGS=--diag_suppress177 -DBLA_VENDOR=Generic
             ctest_options: -E memory
             caching: false
 
@@ -97,7 +97,7 @@ jobs:
             compiler_cxx: ~
             compiler_fc: gfortran-13
             cmake_options: >-
-              -DMPI_ARGS=--oversubscribe -DBLAS_LIBRARIES=/opt/homebrew/opt/lapack/lib/libblas.dylib
+              -DBLAS_LIBRARIES=/opt/homebrew/opt/lapack/lib/libblas.dylib
               "-DLAPACK_LIBRARIES=/opt/homebrew/opt/lapack/lib/libblas.dylib;/opt/homebrew/opt/lapack/lib/liblapack.dylib"
               -DBLA_VENDOR=Generic
             caching: true


### PR DESCRIPTION
intel-one-api installation included intel-mpi. Then we also install open-mpi.
This seems to cause some conflict for the intel-classic CI.
The C compiler automatically adds include directories for intel-mpi, but the linker then links with open-mpi.
This PR removes the installation of intel-mpi for the intel-classic CI.