### PR TITLE
Fix ci failures with nvhpc and intel

### DIFF
--- a/.github/tools/install-nvhpc.sh
+++ b/.github/tools/install-nvhpc.sh
@@ -79,13 +79,29 @@ echo "+ ${TEMPORARY_FILES}/${FOLDER}/install"
 #rm -rf "${TEMPORARY_FILES}/${FOLDER}"
 
 NVHPC_VERSION=$(basename "${NVHPC_INSTALL_DIR}"/Linux_$(uname -m)/*.*/)
+NVHPC_DIR=${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}
 
 # Use gcc which is available in PATH
-${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}/compilers/bin/makelocalrc \
-  -x ${NVHPC_INSTALL_DIR}/Linux_$(uname -m)/${NVHPC_VERSION}/compilers/bin \
+${NVHPC_DIR}/compilers/bin/makelocalrc \
+  -x ${NVHPC_DIR}/compilers/bin \
   -gcc $(which gcc) \
   -gpp $(which g++) \
   -g77 $(which gfortran)
+
+# Locate the bundled OpenMPI prefix. From 25.x the comm_libs/mpi symlink points
+# at hpcx (a bin-only directory), so we derive the real prefix from the location
+# of openmpi-default-hostfile and fall back to comm_libs/mpi for older releases.
+MPI_HOME=$(dirname $(dirname $(find ${NVHPC_DIR}/comm_libs -name openmpi-default-hostfile -path '*/etc/*' 2>/dev/null | head -1)))
+if [ -z "${MPI_HOME}" ] || [ ! -d "${MPI_HOME}" ]; then
+    MPI_HOME=${NVHPC_DIR}/comm_libs/mpi
+fi
+
+# Allow for oversubscription. For open-mpi >= v5.0
+echo "rmaps_default_mapping_policy=:oversubscribe" >> ${MPI_HOME}/etc/prte-mca-params.conf
+
+# Allow for oversubscriptoin. For open-mpi < v5.0 only (older nvhpc versions)
+echo "localhost slots=72" >> ${MPI_HOME}/etc/openmpi-default-hostfile
+
 
 cat > ${NVHPC_INSTALL_DIR}/env.sh << EOF
 ### Variables
@@ -99,7 +115,7 @@ export NVHPC_LIBRARY_PATH=\${NVHPC_DIR}/compilers/lib
 export LD_LIBRARY_PATH=\${NVHPC_LIBRARY_PATH}
 
 ### MPI
-export MPI_HOME=\${NVHPC_DIR}/comm_libs/mpi
+export MPI_HOME=${MPI_HOME}
 export PATH=\${MPI_HOME}/bin:\${PATH}
 EOF
 

--- a/.github/tools/install-nvhpc.sh
+++ b/.github/tools/install-nvhpc.sh
@@ -99,7 +99,7 @@ fi
 # Allow for oversubscription. For open-mpi >= v5.0
 echo "rmaps_default_mapping_policy=:oversubscribe" >> ${MPI_HOME}/etc/prte-mca-params.conf
 
-# Allow for oversubscriptoin. For open-mpi < v5.0 only (older nvhpc versions)
+# Allow for oversubscription. For open-mpi < v5.0 only (older nvhpc versions)
 echo "localhost slots=72" >> ${MPI_HOME}/etc/openmpi-default-hostfile
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -158,6 +158,7 @@ jobs:
         ${ECTRANS_TOOLS}/install-nvhpc.sh --prefix /opt/nvhpc
         source /opt/nvhpc/env.sh
         echo "${NVHPC_DIR}/compilers/bin"                   >> $GITHUB_PATH
+        [ -z ${MPI_HOME+x} ] || echo "MPI_HOME=${MPI_HOME}" >> $GITHUB_ENV
 
     - name: Download Intel compiler
       if: contains( matrix.compiler, 'intel' )
@@ -186,6 +187,7 @@ jobs:
         sudo apt-get install intel-oneapi-toolkit
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
+        [ -z ${I_MPI_ROOT+x} ] || echo "MPI_HOME=${I_MPI_ROOT}" >> $GITHUB_ENV
         echo "CACHE_SUFFIX=$CC-$($CC -dumpversion)" >> $GITHUB_ENV
 
     - name: Install MPI

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -183,7 +183,7 @@ jobs:
       if: contains( matrix.compiler, 'intel-modern' )
       run: |
         sudo apt-get update
-        sudo apt-get install intel-hpckit
+        sudo apt-get install intel-oneapi-toolkit
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
         echo "CACHE_SUFFIX=$CC-$($CC -dumpversion)" >> $GITHUB_ENV


### PR DESCRIPTION
### Description
- It seems that `sudo apt install intel-hpckit` no longer added the `ifx` Fortran compiler in the path with a now updated version of intel-oneapi. I updated this to `sudo apt install intel-oneapi-toolkit`, which seems to provide `ifx` still.
- I updated the `install-nvhpc.sh` script to point MPI_HOME to the correct MPI dir, which had changed over time. This follows the approach in ecmwf-ifs/ecwam#139 .
- I updated the `install-nvhpc.sh` script to enable oversubscription in its MPI config files.
- I updated the workflow to not install open-mpi when it is available in intel-oneapi or nvhpc installation. This fixes a bug in compilation of open-mpi with NVHPC. It also speeds up the CI.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf-ifs/ectrans/blob/develop/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
