### PR TITLE
Remove compile flag overloads for ftinv/ftdir GPU

### DIFF
--- a/src/etrans/gpu/CMakeLists.txt
+++ b/src/etrans/gpu/CMakeLists.txt
@@ -50,15 +50,6 @@ foreach( prec dp sp )
         generate_backend_includes(BACKEND gpu_${prec} TARGET ectrans_lam_gpu_${prec}_includes DESTINATION ${BUILD_INTERFACE_INCLUDE_DIR} INCLUDE_DIRECTORY ${PROJECT_SOURCE_DIR}/src/etrans/include )
         generate_backend_sources( BACKEND gpu_${prec} OUTPUT ectrans_lam_gpu_${prec}_src  DESTINATION ${GENERATED_SOURCE_DIR})
 
-
-        # set custom compilation flags here: keeping as placeholder
-        #if( NOT ${CMAKE_BUILD_TYPE_CAPS} STREQUAL DEBUG )
-        #set_source_files_properties( ${GENERATED_SOURCE_DIR}/internal/ftinv_mod.F90 PROPERTIES COMPILE_OPTIONS "-O2" )
-        #ecbuild_info("warn: special compile flags ftinv_mod.F90")
-        #set_source_files_properties( ${GENERATED_SOURCE_DIR}/internal/ftdir_mod.F90 PROPERTIES COMPILE_OPTIONS "-O2" )
-        #ecbuild_info("warn: special compile flags ftdir_mod.F90")
-        #endif()
-
         ecbuild_add_library(
           TARGET               ectrans_lam_gpu_${prec}
           TYPE                 ${GPU_LIBRARY_TYPE}

--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -133,14 +133,6 @@ foreach( prec dp sp )
         generate_backend_includes(BACKEND gpu_${prec} TARGET ectrans_gpu_${prec}_includes DESTINATION ${BUILD_INTERFACE_INCLUDE_DIR} INCLUDE_DIRECTORY ${PROJECT_SOURCE_DIR}/src/trans/include )
         generate_backend_sources( BACKEND gpu_${prec} OUTPUT ectrans_gpu_${prec}_src  DESTINATION ${GENERATED_SOURCE_DIR})
 
-        #if( NOT ${CMAKE_BUILD_TYPE_CAPS} STREQUAL DEBUG )
-        set_source_files_properties( ${GENERATED_SOURCE_DIR}/internal/ftinv_mod.F90 PROPERTIES COMPILE_OPTIONS "-O2" )
-        ecbuild_info("warn: special compile flags ftinv_mod.F90")
-        set_source_files_properties( ${GENERATED_SOURCE_DIR}/internal/ftdir_mod.F90 PROPERTIES COMPILE_OPTIONS "-O2" )
-        ecbuild_info("warn: special compile flags ftdir_mod.F90")
-        #endif()
-
-
         ecbuild_add_library(
           TARGET               ectrans_gpu_${prec}
           TYPE                 ${GPU_LIBRARY_TYPE}


### PR DESCRIPTION
I found a couple of other instances of `set_source_file_properties` which I'm skeptical of. These were introduced by [this commit](https://github.com/samhatfield/ectrans/commit/dfe7153c8b9e18cbb1a4bb54ad6bd9b5139202ad#diff-672173bb8f228a6159f3b3b58aaf4c4b04aa1c173778d6682cc2e2bb67fcd941R46-R47) 4 years ago. I can't think of a reason why you'd need these overrides, so let's just delete them and see how the build-hpc tests respond.