### PR TITLE
Add prtk PR automation

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,48 @@
+name: check-pr
+
+concurrency:
+  group: prtk-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, edited, ready_for_review, converted_to_draft]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  check-pr:
+    if: github.repository_owner == 'ecmwf-ifs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: 0.6.12
+          enable-cache: false
+
+      - name: Install prtk
+        env:
+          PRTK_READ_ACCESS_TOKEN: ${{ secrets.PRTK_READ_ACCESS }}
+        run: |
+          uv tool install "git+https://${PRTK_READ_ACCESS_TOKEN}@github.com/ecmwf-ifs/prtk"
+
+      - name: Run prtk checks
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >-
+          prtk check
+          --pr-number "${{ github.event.pull_request.number }}"
+          --default-branch "${{ github.event.repository.default_branch }}"
+          --event-name "${{ github.event_name }}"
+          --event-action "${{ github.event.action }}"

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1,0 +1,21 @@
+owner: ecmwf
+
+maintainers:
+  - marsdeno
+
+lead_developers:
+  - samhatfield
+
+checks:
+  ensure-assignee: {}
+  assign-reviewers:
+    exclude-author: true
+    exclude-existing: true
+  copyright-audit:
+    reviewer: msleigh
+    skip-label: "prtk:skip-copyright"
+    allowed-holders:
+      - ECMWF
+      - European Centre for Medium-Range Weather Forecasts
+      - Meteo-France
+      - Meteo France


### PR DESCRIPTION
## Summary

Adds `prtk` PR automation to ectrans. This repo previously had no `MAINTAINERS.yml` and no `prtk` workflow, so this PR introduces both. No Jira and no `cycle_leads`. PRs to any base branch are accepted (no `validate-target-branch`).

### `MAINTAINERS.yml` (new)

- `owner: ecmwf`
- `maintainers: [marsdeno]` — used as the assignee fallback by `ensure-assignee` and contributes to the reviewer pool
- `lead_developers: [samhatfield]` — additional reviewer candidates
- Checks:
  - `ensure-assignee` — every non-draft PR gets one assignee
  - `assign-reviewers` — path-based reviewer requesting (using maintainers + lead_developers), with `exclude-author` and `exclude-existing`
  - `copyright-audit` — advisory comment for suspicious copyright additions, with `allowed-holders` covering ECMWF and Météo-France variants. Skippable per-PR with the `prtk:skip-copyright` label

### `.github/workflows/pr-check.yml` (new)

- `pull_request_target` workflow that runs `prtk check` on `opened, synchronize, reopened, edited, ready_for_review, converted_to_draft`
- Checks out the base SHA (trusted code) and installs `prtk` via `uv tool install` using the org-level `PRTK_READ_ACCESS` secret (already inherited by every `ecmwf-ifs` repo — no per-repo configuration needed)
- `contents: read`, `pull-requests: write`, `issues: write`
- Concurrency group cancels stale runs for the same PR; 5-minute timeout
- Passes `--default-branch` and event metadata so `prtk check` fetches canonical `MAINTAINERS.yml` from the default branch (`develop`) and reacts correctly to event types

### Notes

- The existing `label-public-pr.yml` workflow is unrelated and left in place.
- This PR targets `develop` (the default branch) so `MAINTAINERS.yml` lands where `prtk check` reads it from.

## Test plan

- [ ] Open a draft PR against `develop` and confirm the `prtk` job skips automation (draft handling)
- [ ] Mark the PR ready for review and confirm: one assignee is set, reviewers are requested per `MAINTAINERS.yml`
- [ ] Edit a PR title and confirm `prtk check` re-runs on the `edited` event
