### PR TITLE
Add action to check license header on new files

### DIFF
--- a/.github/tools/check-license-header.py
+++ b/.github/tools/check-license-header.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Check that files contain the ECMWF Apache-2.0 license header as a contiguous block.
+
+The header is stored once in ``license-header.template`` with a ``{comment}``
+placeholder standing in for the comment marker. For each file, the placeholder is
+replaced with the comment marker appropriate to the file's extension (e.g. ``//``
+for C/C++, ``!`` for Fortran, ``#`` for Python/CMake) and the resulting block of
+lines is searched for, contiguously and in order, within the file.
+
+Usage:
+    check-license-header.py FILE [FILE ...]
+
+Exits non-zero if any file is missing the header block.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Map a file extension (lower-case, with leading dot) to its line-comment marker.
+_EXT_COMMENT = {
+    # Fortran
+    ".f90": "!", ".f": "!", ".f77": "!", ".inc": "!",
+    # CMake / Python
+    ".cmake": "#", ".py": "#",
+    # C / C++ and headers
+    ".c": "//", ".cpp": "//", ".cc": "//", ".cxx": "//",
+    ".h": "//", ".hpp": "//", ".hh": "//", ".hxx": "//",
+}
+
+_TEMPLATE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                              "license-header.template")
+
+
+def _comment_marker(path: str) -> str | None:
+    if os.path.basename(path) == "CMakeLists.txt":
+        return "#"
+    # Extensions are matched case-insensitively (.F90 == .f90).
+    return _EXT_COMMENT.get(os.path.splitext(path)[1].lower())
+
+
+def _load_template() -> list[str]:
+    with open(_TEMPLATE_PATH, "r", encoding="utf-8") as fh:
+        return [line.rstrip("\n") for line in fh if line.strip()]
+
+
+def _expected_block(template: list[str], marker: str) -> list[str]:
+    return [line.replace("{comment}", marker) for line in template]
+
+
+def _has_header_block(path: str, template: list[str]) -> bool:
+    marker = _comment_marker(path)
+    if marker is None:
+        print(f"::error file={path}::No comment marker known for {path}")
+        return False
+
+    expected = _expected_block(template, marker)
+
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as fh:
+            lines = [line.rstrip("\n").rstrip() for line in fh]
+    except OSError as exc:
+        print(f"::error file={path}::Could not read {path}: {exc}")
+        return False
+
+    needed = len(expected)
+    for start in range(0, len(lines) - needed + 1):
+        if lines[start : start + needed] == expected:
+            return True
+    return False
+
+
+def main(argv: list[str]) -> int:
+    files = argv[1:]
+    template = _load_template()
+    missing = [f for f in files if not _has_header_block(f, template)]
+
+    print(f"Checked {len(files)} newly added file(s).")
+
+    if missing:
+        print("::error::The following newly added files are missing the required "
+              "license header (it must appear as a contiguous block):")
+        for f in missing:
+            print(f"::error file={f}::Missing license header in {f}")
+            print(f"  - {f}")
+        return 1
+
+    print("All newly added files contain the required license header.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/.github/tools/license-header.template
+++ b/.github/tools/license-header.template
@@ -1,0 +1,5 @@
+{comment} This software is licensed under the terms of the Apache Licence Version 2.0
+{comment} which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+{comment} In applying this licence, ECMWF does not waive the privileges and immunities
+{comment} granted to it by virtue of its status as an intergovernmental organisation
+{comment} nor does it submit to any jurisdiction.

--- a/.github/workflows/check-license-headers.yml
+++ b/.github/workflows/check-license-headers.yml
@@ -58,3 +58,13 @@ jobs:
 
           # Delegate the contiguous-block check to Python for robust normalization.
           python3 "$GITHUB_WORKSPACE/.github/tools/check-license-header.py" "${files_to_check[@]}"
+
+      - name: Show expected license header
+        # Only runs if the check above failed, to remind contributors of the header.
+        if: failure()
+        shell: bash
+        run: |
+          echo "The required license header (with {comment} replaced by the"
+          echo "comment character appropriate to each file type) is:"
+          echo
+          cat "$GITHUB_WORKSPACE/.github/tools/license-header.template"

--- a/.github/workflows/check-license-headers.yml
+++ b/.github/workflows/check-license-headers.yml
@@ -1,0 +1,60 @@
+name: check-license-headers
+
+# Verify that newly added source files carry the ECMWF Apache-2.0 license header.
+on:
+  pull_request: ~
+
+jobs:
+  check-license-headers:
+    name: check-license-headers
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so we can diff against the PR base commit
+          fetch-depth: 0
+
+      - name: Check license headers on newly added files
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          # Only these top-level folders are considered.
+          in_scope_dir() {
+            case "$1" in
+              cmake/*|src/*|tests/*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
+
+          # Only these file types are considered (Fortran, CMake, C/C++, headers, Python).
+          in_scope_type() {
+            case "$1" in
+              *.F90|*.f90|*.F|*.f|*.f77|*.F77|*.inc) return 0 ;;   # Fortran
+              *.cmake|*/CMakeLists.txt|CMakeLists.txt) return 0 ;;  # CMake
+              *.c|*.cpp|*.cc|*.cxx) return 0 ;;                     # C/C++
+              *.h|*.hpp|*.hh|*.hxx) return 0 ;;                     # Headers
+              *.py) return 0 ;;                                     # Python
+              *) return 1 ;;
+            esac
+          }
+
+          # Collect files added in this PR (status = Added only), then filter to scope.
+          files_to_check=()
+          while IFS= read -r f; do
+            [[ -z "$f" ]] && continue
+            in_scope_dir "$f" || continue
+            in_scope_type "$f" || continue
+            [[ -f "$f" ]] || continue
+            files_to_check+=("$f")
+          done < <(git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA")
+
+          echo "Checking ${#files_to_check[@]} newly added file(s)."
+
+          # Delegate the contiguous-block check to Python for robust normalization.
+          python3 "$GITHUB_WORKSPACE/.github/tools/check-license-header.py" "${files_to_check[@]}"

--- a/src/new_file.F90
+++ b/src/new_file.F90
@@ -1,3 +1,9 @@
+! This software is licensed under the terms of the Apache Licence Version 2.0
+! which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+! In applying this licence, ECMWF does not waive the privileges and immunities
+! granted to it by virtue of its status as an intergovernmental organisation
+! nor does it submit to any jurisdiction.
+
 program new_file
     ! This is a test new file which will be deleted later.
     ! It lacks a license header.

--- a/src/new_file.F90
+++ b/src/new_file.F90
@@ -1,0 +1,6 @@
+program new_file
+    ! This is a test new file which will be deleted later.
+    ! It lacks a license header.
+    ! Let's see if the action catches it.
+
+end program new_file    


### PR DESCRIPTION
This action checks that all new files in a PR contain the necessary license header. It checks Fortran, C/C++, Python, and CMake files.

This check does not look for a copyright notice. That's something we could try adding too.

This action was agentically written.