### PR TITLE
Update required ecBuild version to 3.14.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@
 
 cmake_minimum_required( VERSION 3.25 FATAL_ERROR )
 
-find_package( ecbuild 3.14 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild )
+find_package( ecbuild 3.14.2 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild )
 
 project( ectrans LANGUAGES C CXX Fortran )
 include( ectrans_macros )


### PR DESCRIPTION
In order for the compile flag mechanism introduced in #397 and fixed by https://github.com/ecmwf-ifs/ectrans/pull/407 to work properly, ecBuild >= 3.14.2 is required. This requirement should have been added in #407 but I overlooked it. So here it is.