### PR TITLE
Update CI workflow

### DIFF
--- a/.github/actions/should-run/action.yml
+++ b/.github/actions/should-run/action.yml
@@ -1,0 +1,77 @@
+name: should-run
+description: Decide whether a workflow job should run for the current GitHub event.
+
+outputs:
+  value:
+    description: "true when the job should run; false when this is a duplicate push event"
+    value: ${{ steps.decision.outputs.value }}
+
+runs:
+  using: composite
+  steps:
+    - name: Skip duplicate push builds only when PR CI can run
+      id: decision
+      uses: actions/github-script@v9
+      with:
+        script: |
+          // Workflows using this action are triggered by both `push` and
+          // `pull_request`. For a same-repository PR, every push to the PR
+          // branch can trigger both events for the same commit. We keep the
+          // pull_request build and skip only the duplicate push build when
+          // GitHub can actually create that pull_request build.
+          if (context.eventName !== 'push') {
+            core.setOutput('value', 'true');
+            return;
+          }
+
+          const { owner, repo } = context.repo;
+          const branch = context.ref.replace('refs/heads/', '');
+
+          // `head` uses owner:branch syntax and only matches PRs opened from
+          // this repository. Fork PRs do not create duplicate same-repo push
+          // events here, so they are not filtered by this check.
+          const pulls = await github.rest.pulls.list({
+            owner,
+            repo,
+            head: `${owner}:${branch}`,
+            state: 'open',
+            per_page: 10,
+          });
+
+          if (pulls.data.length === 0) {
+            core.setOutput('value', 'true');
+            return;
+          }
+
+          // GitHub does not run pull_request workflows when a PR has merge
+          // conflicts with its base branch. In that case, the push workflow
+          // is the only CI signal for the pushed commit, so it must run.
+          // If mergeability is still being computed, keep the push build too;
+          // a duplicate build is better than accidentally losing coverage.
+          let pullRequestBuildCanRun = false;
+          for (const pull of pulls.data) {
+            const details = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pull.number,
+            });
+
+            const mergeable = details.data.mergeable;
+            const mergeableState = details.data.mergeable_state;
+
+            if (mergeable === false || mergeableState === 'dirty') {
+              core.info(`PR #${pull.number} has merge conflicts; keeping push build.`);
+              continue;
+            }
+
+            if (mergeable === null || mergeableState === 'unknown') {
+              core.info(`PR #${pull.number} mergeability is unknown; keeping push build.`);
+              continue;
+            }
+
+            pullRequestBuildCanRun = true;
+            core.info(`PR #${pull.number} can run pull_request CI; skipping duplicate push build.`);
+            break;
+          }
+
+          core.setOutput('value', pullRequestBuildCanRun ? 'false' : 'true');

--- a/.github/tools/install-fftw.sh
+++ b/.github/tools/install-fftw.sh
@@ -74,21 +74,21 @@ tar xzf ${fftw_tarball} -C ${TMPDIR}/downloads
 echo "+ cd ${fftw_dir}"
 cd ${fftw_dir}
 echo "+ ./configure --prefix=${PREFIX} ${fftw_configure}"
-./configure --prefix=${PREFIX} ${fftw_configure}
+${SCRIPTDIR}/reduce-output.sh ./configure --prefix=${PREFIX} ${fftw_configure}
 echo "+ make -j8"
-make -j8
+${SCRIPTDIR}/reduce-output.sh make -j8
 echo "+ make install"
-make install
+${SCRIPTDIR}/reduce-output.sh make install
 
 if $fftw_with_single; then
   # Now again in single precision
-  make clean
+  ${SCRIPTDIR}/reduce-output.sh make clean
   echo "+ ./configure --prefix=${PREFIX} ${fftw_configure} --enable-float"
-  ./configure --prefix=${PREFIX} ${fftw_configure} --enable-float
+  ${SCRIPTDIR}/reduce-output.sh ./configure --prefix=${PREFIX} ${fftw_configure} --enable-float
   echo "+ make -j8"
-  make -j8
+  ${SCRIPTDIR}/reduce-output.sh make -j8
   echo "+ make install"
-  make install
+  ${SCRIPTDIR}/reduce-output.sh make install
 fi
 
 

--- a/.github/workflows/build-ectrans4py.yml
+++ b/.github/workflows/build-ectrans4py.yml
@@ -22,8 +22,29 @@ env:
   CACHE_SUFFIX: v1        # Increase to force new cache to be created
 
 jobs:
+  should-run:
+    name: decide whether to run build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      value: ${{ steps.decision.outputs.value }}
+    steps:
+      - name: Checkout reusable workflow action
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/should-run
+
+      - name: Decide whether this build should run
+        id: decision
+        uses: ./.github/actions/should-run
+
   ci:
     name: ci
+    needs: should-run
+    if: needs.should-run.outputs.value == 'true'
 
     strategy:
       fail-fast: false    # false: try to complete all jobs
@@ -81,6 +102,8 @@ jobs:
         echo "FC=${{ matrix.compiler_fc }}"     >> $GITHUB_ENV
 
         if [[ "${{ matrix.os }}" =~ macos ]]; then
+          # GitHub-hosted macOS runners can include aws/tap, which Homebrew may reject as untrusted during auto-update.
+          brew untap aws/tap || true
           brew install ninja
         else
           sudo apt-get update

--- a/.github/workflows/build-ectrans4py.yml
+++ b/.github/workflows/build-ectrans4py.yml
@@ -57,19 +57,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout ecBuild
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: ecmwf/ecbuild
         path: ecbuild
 
     - name: Checkout FIAT
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: ecmwf-ifs/fiat
         path: fiat
 
     - name: Checkout ecTrans
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         path: ectrans
 

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -62,7 +62,6 @@ jobs:
 
         include:
           - name: ac-ops intel
-            path_name: ac-ops_intel
             site: ac-batch
             troika_user_secret: HPC_CI_SSH_USER
             arch: ecmwf/hpc2020/intel/2023.2.0/hpcx-openmpi/2.9.0
@@ -78,7 +77,6 @@ jobs:
               - CMAKE_GENERATOR=Ninja
 
           - name: ac-gpu nvhpc
-            path_name: ac-gpu_nvhpc
             site: ac-batch
             troika_user_secret: HPC_CI_SSH_USER
             arch: ecmwf/hpc2020/nvhpc/24.5/hpcx-openmpi/2.19.0-cuda
@@ -94,7 +92,6 @@ jobs:
               - CMAKE_GENERATOR=Ninja
 
           - name: lumi-g cce
-            path_name: lumi-g_cce
             site: lumi
             troika_user_secret: LUMI_CI_SSH_USER
             account_secret: LUMI_CI_PROJECT
@@ -118,8 +115,8 @@ jobs:
     runs-on: [self-hosted, linux, hpc]
     env:
       GH_TOKEN: ${{ github.token }}
-      OUTPUT_DIR: ${{ format('/scratch/{0}/github-actions/ectrans/{1}/{2}/{3}', secrets[matrix.account_secret || matrix.troika_user_secret], matrix.path_name, github.run_id, github.run_attempt) }}
-      WORKDIR: ${{ format('/scratch/{0}/github-actions/ectrans/{1}/{2}/{3}', secrets[matrix.account_secret || matrix.troika_user_secret], matrix.path_name, github.run_id, github.run_attempt) }}
+      OUTPUT_DIR: ${{ format('/scratch/{0}/github-actions/ectrans/{1}/{2}/{3}', secrets[matrix.account_secret || matrix.troika_user_secret], github.run_id, strategy.job-index, github.run_attempt) }}
+      WORKDIR: ${{ format('/scratch/{0}/github-actions/ectrans/{1}/{2}/{3}', secrets[matrix.account_secret || matrix.troika_user_secret], github.run_id, strategy.job-index, github.run_attempt) }}
     steps:
       - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
         with:

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -62,6 +62,7 @@ jobs:
 
         include:
           - name: ac-ops intel
+            path_name: ac-ops_intel
             site: ac-batch
             troika_user_secret: HPC_CI_SSH_USER
             arch: ecmwf/hpc2020/intel/2023.2.0/hpcx-openmpi/2.9.0
@@ -73,12 +74,13 @@ jobs:
               #SBATCH --gpus-per-task=0
               #SBATCH --mem=200G
               #SBATCH --qos=np
-            output_dir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
-            workdir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
+            output_dir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
+            workdir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
             env_vars:
               - CMAKE_GENERATOR=Ninja
 
           - name: ac-gpu nvhpc
+            path_name: ac-gpu_nvhpc
             site: ac-batch
             troika_user_secret: HPC_CI_SSH_USER
             arch: ecmwf/hpc2020/nvhpc/24.5/hpcx-openmpi/2.19.0-cuda
@@ -90,12 +92,13 @@ jobs:
               #SBATCH --gpus-per-task=1
               #SBATCH --mem=200G
               #SBATCH --qos=ng
-            output_dir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
-            workdir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
+            output_dir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
+            workdir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
             env_vars:
               - CMAKE_GENERATOR=Ninja
 
           - name: lumi-g cce
+            path_name: lumi-g_cce
             site: lumi
             troika_user_secret: LUMI_CI_SSH_USER
             account_secret: LUMI_CI_PROJECT
@@ -107,8 +110,8 @@ jobs:
               #SBATCH --gpus-per-task=1
               #SBATCH --partition=standard-g
               #SBATCH --account={0}
-            output_dir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
-            workdir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
+            output_dir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
+            workdir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
             env_vars:
               - ROCFFT_RTC_CACHE_PATH=$PWD/../../rocfft_kernel_cache.db
               - MPICH_GPU_SUPPORT_ENABLED=1

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -74,8 +74,6 @@ jobs:
               #SBATCH --gpus-per-task=0
               #SBATCH --mem=200G
               #SBATCH --qos=np
-            output_dir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
-            workdir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
             env_vars:
               - CMAKE_GENERATOR=Ninja
 
@@ -92,8 +90,6 @@ jobs:
               #SBATCH --gpus-per-task=1
               #SBATCH --mem=200G
               #SBATCH --qos=ng
-            output_dir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
-            workdir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
             env_vars:
               - CMAKE_GENERATOR=Ninja
 
@@ -110,8 +106,6 @@ jobs:
               #SBATCH --gpus-per-task=1
               #SBATCH --partition=standard-g
               #SBATCH --account={0}
-            output_dir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
-            workdir: /scratch/{0}/github-actions/ectrans/${{ matrix.path_name }}/${{ github.run_id }}/${{ github.run_attempt }}
             env_vars:
               - ROCFFT_RTC_CACHE_PATH=$PWD/../../rocfft_kernel_cache.db
               - MPICH_GPU_SUPPORT_ENABLED=1
@@ -124,8 +118,8 @@ jobs:
     runs-on: [self-hosted, linux, hpc]
     env:
       GH_TOKEN: ${{ github.token }}
-      OUTPUT_DIR: ${{ format(matrix.output_dir, secrets[matrix.account_secret || matrix.troika_user_secret]) || '' }}
-      WORKDIR: ${{ format(matrix.workdir, secrets[matrix.account_secret || matrix.troika_user_secret]) || '' }}
+      OUTPUT_DIR: ${{ format('/scratch/{0}/github-actions/ectrans/{1}/{2}/{3}', secrets[matrix.account_secret || matrix.troika_user_secret], matrix.path_name, github.run_id, github.run_attempt) }}
+      WORKDIR: ${{ format('/scratch/{0}/github-actions/ectrans/{1}/{2}/{3}', secrets[matrix.account_secret || matrix.troika_user_secret], matrix.path_name, github.run_id, github.run_attempt) }}
     steps:
       - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
         with:

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -135,7 +135,6 @@ jobs:
             site: ${{ matrix.site }}
             arch: ${{ matrix.arch }}
             cmake_options:
-              - -DENABLE_MPI=ON
               - -DENABLE_ETRANS=ON
               - -DENABLE_FIELD_API=ON
             ctest_options: ${{ matrix.ctest_options || '' }}

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -27,9 +27,29 @@ env:
   CACHE_SUFFIX: v1        # Increase to force new cache to be created
 
 jobs:
+  should-run:
+    name: decide whether to run build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      value: ${{ steps.decision.outputs.value }}
+    steps:
+      - name: Checkout reusable workflow action
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/should-run
+
+      - name: Decide whether this build should run
+        id: decision
+        uses: ./.github/actions/should-run
+
   ci-hpc:
     name: ci-hpc
-    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    needs: should-run
+    if: ${{ needs.should-run.outputs.value == 'true' && (!github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci') }}
 
     strategy:
       fail-fast: false    # false: try to complete all jobs
@@ -53,6 +73,8 @@ jobs:
               #SBATCH --gpus-per-task=0
               #SBATCH --mem=200G
               #SBATCH --qos=np
+            output_dir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
+            workdir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
             env_vars:
               - CMAKE_GENERATOR=Ninja
 
@@ -68,6 +90,8 @@ jobs:
               #SBATCH --gpus-per-task=1
               #SBATCH --mem=200G
               #SBATCH --qos=ng
+            output_dir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
+            workdir: /scratch/{0}/github-actions/ectrans/${{ github.run_id }}/${{ github.run_attempt }}
             env_vars:
               - CMAKE_GENERATOR=Ninja
 
@@ -97,14 +121,16 @@ jobs:
     runs-on: [self-hosted, linux, hpc]
     env:
       GH_TOKEN: ${{ github.token }}
+      OUTPUT_DIR: ${{ format(matrix.output_dir, secrets[matrix.account_secret || matrix.troika_user_secret]) || '' }}
+      WORKDIR: ${{ format(matrix.workdir, secrets[matrix.account_secret || matrix.troika_user_secret]) || '' }}
     steps:
       - uses: ecmwf-actions/reusable-workflows/ci-hpc-generic@v2
         with:
           site: ${{ matrix.site }}
           troika_user: ${{ secrets[matrix.troika_user_secret] }}
           sbatch_options: ${{ format(matrix.sbatch_options, secrets[matrix.account_secret]) }}
-          output_dir: ${{ format(matrix.output_dir, secrets[matrix.account_secret]) || '' }}
-          workdir: ${{ format(matrix.workdir, secrets[matrix.account_secret]) || '' }}
+          output_dir: ${{ env.OUTPUT_DIR }}
+          workdir: ${{ env.WORKDIR }}
           template_data: |
             site: ${{ matrix.site }}
             arch: ${{ matrix.arch }}
@@ -137,6 +163,17 @@ jobs:
 
               rm -r $REPO
               rm -r build
+
+              {% for name in dependencies.keys() %}
+                {% if name != unsupported_dependency %}
+                  {% set org, proj = name.split('/') %}
+                  rmdir {{org}} 2>/dev/null || true
+                {% endif %}
+              {% endfor %}
+              repo_owner=$(dirname "$REPO")
+              if [ "$repo_owner" != "." ]; then
+                rmdir "$repo_owner" 2>/dev/null || true
+              fi
             }
             error_trap() {
               cleanup
@@ -212,4 +249,3 @@ jobs:
             ctest --test-dir build --output-on-failure {{ ctest_options }}
 
             cleanup
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,7 +333,7 @@ jobs:
         dependency_cmake_options: |
           ecmwf-ifs/fiat:      "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_MPI=ON"
           ecmwf-ifs/field_api: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_CUDA=OFF"
-        cmake_options:         "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_options }} -DENABLE_FFTW=ON -DENABLE_ETRANS=ON -DENABLE_MKL=OFF -DENABLE_FIELD_API=ON"
+        cmake_options:         "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_options }} -DENABLE_ETRANS=ON -DENABLE_MKL=OFF -DENABLE_FIELD_API=ON"
         ctest_options: "${{ matrix.ctest_options }}"
 
     - name: Verify tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,11 +19,32 @@ on:
 env:
   ECTRANS_TOOLS: ${{ github.workspace }}/.github/tools
   CTEST_PARALLEL_LEVEL: 1
-  CACHE_SUFFIX: v2        # Increase to force new cache to be created
+  CACHE_SUFFIX: v3        # Increase to force new cache to be created
 
 jobs:
+  should-run:
+    name: decide whether to run build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      value: ${{ steps.decision.outputs.value }}
+    steps:
+      - name: Checkout reusable workflow action
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          sparse-checkout: .github/actions/should-run
+
+      - name: Decide whether this build should run
+        id: decision
+        uses: ./.github/actions/should-run
+
   ci:
     name: ci
+    needs: should-run
+    if: needs.should-run.outputs.value == 'true'
 
     strategy:
       fail-fast: false    # false: try to complete all jobs
@@ -68,7 +89,7 @@ jobs:
             compiler_fc: nvfortran
             cmake_options: -DBLA_VENDOR=Generic
             ctest_options: -E memory
-            caching: false
+            caching: true
 
           - name : linux intel-classic
             os: ubuntu-22.04
@@ -96,10 +117,7 @@ jobs:
             compiler_cc: ~
             compiler_cxx: ~
             compiler_fc: gfortran-13
-            cmake_options: >-
-              -DBLAS_LIBRARIES=/opt/homebrew/opt/lapack/lib/libblas.dylib
-              "-DLAPACK_LIBRARIES=/opt/homebrew/opt/lapack/lib/libblas.dylib;/opt/homebrew/opt/lapack/lib/liblapack.dylib"
-              -DBLA_VENDOR=Generic
+            cmake_options: -DBLA_VENDOR=Generic
             caching: true
 
     runs-on: ${{ matrix.os }}
@@ -115,37 +133,12 @@ jobs:
         fi
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.11
 
     - name: Checkout Repository
-      uses: actions/checkout@v2
-
-    - name: Environment
-      run:  |
-        echo "DEPS_DIR=${{ runner.temp }}/deps" >> $GITHUB_ENV
-        echo "CC=${{ matrix.compiler_cc }}"     >> $GITHUB_ENV
-        echo "CXX=${{ matrix.compiler_cxx }}"   >> $GITHUB_ENV
-        echo "FC=${{ matrix.compiler_fc }}"     >> $GITHUB_ENV
-
-        if [[ "${{ matrix.os }}" =~ macos ]]; then
-          brew install ninja
-        else
-          sudo apt-get update
-          sudo apt-get install ninja-build
-        fi
-
-        printenv
-
-    - name: Cache Dependencies
-      # There seems to be a problem with cached NVHPC dependencies, leading to SIGILL perhaps due to slightly different architectures
-      if: matrix.caching
-      id: deps-cache
-      uses: pat-s/always-upload-cache@v2.1.5
-      with:
-        path: ${{ env.DEPS_DIR }}
-        key: deps-${{ matrix.os }}-${{ matrix.compiler }}-${{ matrix.build_type }}-${{ env.CACHE_SUFFIX }}
+      uses: actions/checkout@v7
 
     # Free up disk space for nvhpc
     - name: Free Disk Space (Ubuntu)
@@ -204,6 +197,71 @@ jobs:
         [ -z ${I_MPI_ROOT+x} ] || echo "MPI_HOME=${I_MPI_ROOT}" >> $GITHUB_ENV
         echo "CACHE_SUFFIX=$CC-$($CC -dumpversion)" >> $GITHUB_ENV
 
+    - name: Environment
+      run:  |
+        echo "DEPS_DIR=${{ runner.temp }}/deps" >> $GITHUB_ENV
+        echo "CC=${{ matrix.compiler_cc }}"     >> $GITHUB_ENV
+        echo "CXX=${{ matrix.compiler_cxx }}"   >> $GITHUB_ENV
+        echo "FC=${{ matrix.compiler_fc }}"     >> $GITHUB_ENV
+
+        if [[ "${{ matrix.os }}" =~ macos ]]; then
+          # GitHub-hosted macOS runners can include aws/tap, which Homebrew may reject as untrusted during auto-update.
+          brew untap aws/tap || true
+          brew install ninja
+        else
+          sudo apt-get update
+          sudo apt-get install ninja-build
+        fi
+
+        printenv
+
+    - name: Dependency cache key
+      id: dependency-cache-key
+      shell: bash -eux {0}
+      run: |
+        echo "value=deps-${{ matrix.os }}-${{ matrix.compiler }}-${CACHE_SUFFIX}" >> $GITHUB_OUTPUT
+
+    - name: Restore dependencies cache
+      if: matrix.caching
+      id: deps-cache
+      uses: actions/cache/restore@v6
+      with:
+        path: ${{ runner.temp }}/deps
+        key: ${{ steps.dependency-cache-key.outputs.value }}
+
+
+    - name: Set compile flags
+      shell: bash -eux {0}
+      run: |
+        # Define flags to ensure a common baseline for the x86_64 runners, which have a mix of AMD and Intel processors.
+        # This should make builds reproducible across runners to compare references.
+        # This is also needed for self-compiled FFTW!
+        #
+        # Regardless of reproducibility across runners nvhpc needs the "-march=x86-64-v3" flag,
+        # which is needed to avoid nvfortran errors of "Error during math dispatching processing..."
+        # It seems the compiler detects an incompatible target processor on some of the runners,
+        # in particular -tp=znver4 seems incompatible with "AMD EPYC 9V74 80-Core Processor" as shown by /proc/cpuinfo.
+
+        TARGET_FLAGS="-march=x86-64-v3"
+        if [[ "${{ matrix.os }}" =~ macos ]]; then
+          # macos runners are all Apple Silicon, so we use the native architecture for reproducibility across runners.
+          TARGET_FLAGS="-march=native"
+        fi
+        if [[ "${{ matrix.compiler }}" == "intel-classic" ]]; then
+          # Classic intel compiler does not recognize -march=x86-64-v3, so we use -march=core-avx2 instead.
+          TARGET_FLAGS="-march=core-avx2"
+        fi
+
+        MATH_FLAGS="-ffp-contract=off -fno-fast-math"
+        if [[ "${{ matrix.compiler }}" =~ "nvhpc" ]]; then
+          MATH_FLAGS="-Kieee -Mnofma"
+        fi
+        if [[ "${{ matrix.compiler }}" =~ "intel" ]]; then
+          MATH_FLAGS="-fp-model consistent"
+        fi
+
+        echo "COMPILE_FLAGS=${TARGET_FLAGS} ${MATH_FLAGS}" >> $GITHUB_ENV
+
     - name: Install MPI
       shell: bash -eux {0}
       run: |
@@ -214,12 +272,24 @@ jobs:
     - name: Install FFTW
       shell: bash -eux {0}
       run: |
-        ${ECTRANS_TOOLS}/install-fftw.sh --version 3.3.10 --with-single --prefix ${DEPS_DIR}/fftw
+        CFLAGS="-fPIC ${COMPILE_FLAGS}" ${ECTRANS_TOOLS}/install-fftw.sh --version 3.3.10 --with-single --prefix ${DEPS_DIR}/fftw
         echo "FFTW_ROOT=${DEPS_DIR}/fftw" >> $GITHUB_ENV
 
+        if [[ "${{ matrix.os }}" != macos ]]; then
+          echo "ECTRANS_FFTW_CFLAGS=-fPIC ${COMPILE_FLAGS}" >> $GITHUB_ENV
+        fi
     - name: Install reference BLAS/LAPACK
       shell: bash -eux {0}
-      run: ${ECTRANS_TOOLS}/install-ref-blas-lapack.sh
+      run: |
+        ${ECTRANS_TOOLS}/install-ref-blas-lapack.sh
+        echo "ECTRANS_LAPACK_VENDOR=Netlib" >> $GITHUB_ENV
+
+    - name: Save dependencies cache
+      if: always() && matrix.caching && matrix.build_type == 'Debug' && steps.deps-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v6
+      with:
+        path: ${{ runner.temp }}/deps
+        key: ${{ steps.dependency-cache-key.outputs.value }}
 
     - name: Set Build & Test Environment
       run: |
@@ -237,21 +307,19 @@ jobs:
         echo "UCX_NET_DEVICES=lo"  >> $GITHUB_ENV
         echo "UCX_LOG_LEVEL=error" >> $GITHUB_ENV
 
-        if [[ "${{ matrix.compiler }}" =~ "nvhpc" ]]; then
-          # Add a -tp=haswell flag, which is needed to avoid nvfortran errors of "Error during math dispatching processing..."
-          # It seems the compiler detects an incompatible target processor on some of the runners,
-          # in particular -tp=znver4 seems incompatible with "AMD EPYC 9V74 80-Core Processor" as shown by /proc/cpuinfo
-          NVHPC_TARGET_FLAG="-tp=haswell"
-          echo "set( ECBUILD_Fortran_FLAGS ${NVHPC_TARGET_FLAG} )" >> $PWD/toolchain.cmake
-          echo "set( ECBUILD_C_FLAGS ${NVHPC_TARGET_FLAG} )"       >> $PWD/toolchain.cmake
-          echo "set( ECBUILD_CXX_FLAGS ${NVHPC_TARGET_FLAG} )"     >> $PWD/toolchain.cmake
-
-          echo "CMAKE_TOOLCHAIN_FILE=$PWD/toolchain.cmake" >> $GITHUB_ENV
+        if [[ "${{ matrix.os }}" =~ macos ]]; then
+          echo "CMAKE_PREFIX_PATH=/opt/homebrew/opt/lapack${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}" >> $GITHUB_ENV
         fi
+
+        echo "set( ECBUILD_Fortran_FLAGS \"${COMPILE_FLAGS}\" )" >> $PWD/toolchain.cmake
+        echo "set( ECBUILD_C_FLAGS \"${COMPILE_FLAGS}\" )"       >> $PWD/toolchain.cmake
+        echo "set( ECBUILD_CXX_FLAGS \"${COMPILE_FLAGS}\" )"     >> $PWD/toolchain.cmake
+        cat $PWD/toolchain.cmake
+        echo "CMAKE_TOOLCHAIN_FILE=$PWD/toolchain.cmake" >> $GITHUB_ENV
 
     - name: Build & Test
       id: build-test
-      uses: ecmwf-actions/build-package@v2
+      uses: ecmwf/build-package@v2
       with:
         self_coverage: false
         force_build: true
@@ -263,8 +331,9 @@ jobs:
           ecmwf-ifs/field_api@refs/tags/v0.3.9
         dependency_branch: develop
         dependency_cmake_options: |
-          ecmwf-ifs/fiat: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_MPI=ON"
-        cmake_options:    "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_options }} -DENABLE_MPI=ON -DENABLE_FFTW=ON -DENABLE_ETRANS=ON -DENABLE_MKL=OFF -DENABLE_FIELD_API=ON"
+          ecmwf-ifs/fiat:      "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_MPI=ON"
+          ecmwf-ifs/field_api: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_CUDA=OFF"
+        cmake_options:         "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_options }} -DENABLE_MPI=ON -DENABLE_FFTW=ON -DENABLE_ETRANS=ON -DENABLE_MKL=OFF -DENABLE_FIELD_API=ON"
         ctest_options: "${{ matrix.ctest_options }}"
 
     - name: Verify tools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -333,7 +333,7 @@ jobs:
         dependency_cmake_options: |
           ecmwf-ifs/fiat:      "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_MPI=ON"
           ecmwf-ifs/field_api: "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DENABLE_TESTS=OFF -DENABLE_CUDA=OFF"
-        cmake_options:         "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_options }} -DENABLE_MPI=ON -DENABLE_FFTW=ON -DENABLE_ETRANS=ON -DENABLE_MKL=OFF -DENABLE_FIELD_API=ON"
+        cmake_options:         "-G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} ${{ matrix.cmake_options }} -DENABLE_FFTW=ON -DENABLE_ETRANS=ON -DENABLE_MKL=OFF -DENABLE_FIELD_API=ON"
         ctest_options: "${{ matrix.ctest_options }}"
 
     - name: Verify tools

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 


### PR DESCRIPTION
### Description

While working on PR #434 I made quite a number of improvements to the workflows that should really be a PR in its own right, also to make the review more manageable. This PR focuses on modernising the CI workflows in preparation.

This pull request introduces several improvements to the GitHub Actions CI workflows, focusing on smarter job execution to avoid duplicate builds, improved dependency caching, and more consistent and reproducible build environments. The main changes are the addition of a reusable action to skip redundant CI jobs, refactoring of caching logic, and standardization of compile flags for cross-runner consistency.

**Workflow execution improvements:**

* Added a reusable composite action (`.github/actions/should-run`) that determines whether a workflow job should run, preventing duplicate builds for the same commit when both `push` and `pull_request` events are triggered. This logic is now used in both `build.yml` and `build-hpc.yml` workflows to conditionally run CI jobs. 

**Dependency caching and environment setup:**

* Refactored dependency caching logic to use explicit cache key generation, separate restore and save steps, and enabled caching for more build matrix entries. The dependency cache is now only saved for Debug builds and when not already hit. 
* Moved environment setup and dependency installation steps to after repository checkout, and updated the Python setup and checkout actions to latest versions (`actions/setup-python@v7`, `actions/checkout@v7`).

**Build reproducibility and flags:**

* Standardized compile flags across runners and compilers to ensure reproducible builds, including setting `-march=x86-64-v3` for Linux (AVX2 instructions but not AVX512), `-march=native` for macOS, and appropriate math flags for different compilers, disabling FMA and strict IEEE compliance.
These flags are used for general compilation of the ECMWF packages, but also for FFTW, as that is important for bit-reproducibility across all AMD/Intel hardware used.

**Workflow matrix and configuration changes:**

* Simplified and standardized CMake options for matrix entries
* Enabled caching for more builds.
* Added explicit LAPACK vendor configuration and improved handling of BLAS/LAPACK paths on macOS. It seemed that a combination of Netlib and Accelerate was still used on macOS.

**HPC workflow improvements:**

* Updated the `build-hpc.yml` workflow to use the new conditional execution logic and standardized output/work directories using job and attempt IDs for better isolation.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf-ifs/ectrans/blob/develop/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
