### PR TITLE
Update checksums in ectrans-benchmark and ectrans-lam-benchmark

### DIFF
--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -65,6 +65,7 @@ integer(kind=jpim) :: iters   = 10  ! Number of iterations for transform test
 integer(kind=jpim) :: nfld    = 1   ! Number of 3D scalar fields
 integer(kind=jpim) :: nlev    = 1   ! Number of vertical levels
 integer(kind=jpim) :: iters_warmup = 3 ! Number of warm up steps (for which timing statistics should be ignored)
+integer(kind=jpim) :: iters_checksums = -1 ! Number of iterations for which checksum output is written
 
 integer(kind=jpim) :: nflevg  ! Total number of vertical levels
 
@@ -239,7 +240,9 @@ endif
 call get_command_line_arguments(nsmax, cgrid, iters, iters_warmup, nfld, nlev, lvordiv, lscders, &
   &                             luvder, luseflt, nopt_mem_tr, nproma, npromatr, verbosity, &
   &                             ldump_values, lprint_norms, lmeminfo, nprtrv, nprtrw, ncheck, &
-  &                             lpinning, lfield_api, icall_mode, ldump_checksums, cchecksums_path, lalloperm)
+  &                             lpinning, lfield_api, icall_mode, ldump_checksums, iters_checksums, &
+  &                             cchecksums_path, lalloperm)
+if (iters_checksums < 0) iters_checksums = iters_warmup
 if (cgrid == '') cgrid = cubic_octahedral_gaussian_grid(nsmax)
 call parse_grid(cgrid, ndgl, nloen)
 nflevg = nlev
@@ -728,7 +731,7 @@ do jstep = 1, iters+iters_warmup
       &            ldscders=lscders, ldvorgp=lvordiv, lddivgp=lvordiv, lduvder=luvder, kproma=nproma)
   endif
 
-  if (ldump_checksums) then
+  if (ldump_checksums .and. jstep <= iters_checksums) then
     ! Remove trash at end of last block
     iend = ngptot - nproma * (ngpblks - 1)
     if (icall_mode == 1) then
@@ -808,7 +811,7 @@ do jstep = 1, iters+iters_warmup
       &            kvsetuv=ivset, kvsetsc2=ivsetsc2, kvsetsc3a=ivset, kproma=nproma)
   endif
 
-  if (ldump_checksums) then
+  if (ldump_checksums .and. jstep <= iters_checksums) then
 
     if (icall_mode == 1) then
       call dump_checksums_psp(filename=cchecksums_path, noutdump=noutdump_checksum, &
@@ -1264,6 +1267,8 @@ subroutine print_help(unit)
     & iterations (default = 10)"
   write(nout, "(a)") "    --niter-warmup      Number of warm up iterations,&
     & for which timing statistics should be ignored (default = 3)"
+  write(nout, "(a)") "    --niter-checksums  Number of iterations for which checksum output is&
+    & written, counting warmup iterations too (default = --niter-warmup)"
   write(nout, "(a)") "    -f, --nfld NFLD     Number of scalar fields (default = 1)"
   write(nout, "(a)") "    -l, --nlev NLEV     Number of vertical levels (default = 1)"
   write(nout, "(a)") "    --vordiv            Also transform vorticity-divergence to wind"
@@ -1325,6 +1330,7 @@ subroutine get_command_line_arguments(nsmax, cgrid, iters, iters_warmup, nfld, n
   &                                   lscders, luvder, luseflt, nopt_mem_tr, nproma, npromatr, &
   &                                   verbosity, ldump_values, lprint_norms, lmeminfo, nprtrv, &
   &                                   nprtrw, ncheck, lpinning, lfield_api, icall_mode, ldump_checksums, &
+  &                                   iters_checksums, &
   &                                   cchecksums_path, lalloperm)
 
 #ifdef _OPENACC
@@ -1335,6 +1341,7 @@ subroutine get_command_line_arguments(nsmax, cgrid, iters, iters_warmup, nfld, n
   character(len=16), intent(inout) :: cgrid ! Grid
   integer, intent(inout) :: iters           ! Number of iterations for transform test
   integer, intent(inout) :: iters_warmup    ! Number of iterations for transform test
+  integer, intent(inout) :: iters_checksums ! Number of iterations for which checksum output is written
   integer, intent(inout) :: nfld            ! Number of scalar fields
   integer, intent(inout) :: nlev            ! Number of vertical levels
   logical, intent(inout) :: lvordiv         ! Also transform vorticity/divergence
@@ -1393,6 +1400,11 @@ subroutine get_command_line_arguments(nsmax, cgrid, iters, iters_warmup, nfld, n
         iters_warmup = get_int_value('--niter-warmup', iarg)
         if (iters_warmup < 0) then
           call parsing_failed("Invalid argument for --niter-warmup: must be >= 0")
+        end if
+      case('--niter-checksums')
+        iters_checksums = get_int_value('--niter-checksums', iarg)
+        if (iters_checksums < 0) then
+          call parsing_failed("Invalid argument for --niter-checksums: must be >= 0")
         end if
       ! Parse spectral truncation argument
       case('-t', '--truncation')

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -183,7 +183,6 @@ type(fields_lists) :: ylf
 logical :: ldump_values = .false.
 logical :: lpinning = .false.
 logical :: ldump_checksums = .false.
-character(len=1024) :: checksums_filename
 
 integer, external :: ec_mpirank
 logical :: luse_mpi = .true.
@@ -722,11 +721,10 @@ do jstep = 1, iters+iters_warmup
   if (ldump_checksums) then
     ! Remove trash at end of last block
     iend = ngptot - nproma * (ngpblks - 1)
-    write (checksums_filename,'(A)') trim(cchecksums_path)
     if (icall_mode == 1) then
       ! Remove trash at end of last block
       zgp (iend+1:, :, ngpblks) = 0
-      call dump_checksums_pgp(filename=checksums_filename, noutdump=noutdump_checksum, &
+      call dump_checksums_pgp(filename=cchecksums_path, noutdump=noutdump_checksum, &
                             & jstep=jstep, myproc=myproc, nproma=nproma, ngptotg=ngptotg, &
                             & zgp=zgp)
     else
@@ -734,7 +732,7 @@ do jstep = 1, iters+iters_warmup
       zgpuv (iend+1:, :, :, ngpblks) = 0
       zgp3a (iend+1:, :, :, ngpblks) = 0
       zgp2 (iend+1:, :, ngpblks) = 0
-      call dump_checksums_pgp_uv_3a_2(filename=checksums_filename, noutdump=noutdump_checksum, &
+      call dump_checksums_pgp_uv_3a_2(filename=cchecksums_path, noutdump=noutdump_checksum, &
                                     & jstep=jstep, myproc=myproc, nproma=nproma, ngptotg=ngptotg, &
                                     & lscders=lscders, luvder=luvder, zgpuv=zgpuv, zgp3a=zgp3a, zgp2=zgp2)
     endif
@@ -799,15 +797,14 @@ do jstep = 1, iters+iters_warmup
   endif
 
   if (ldump_checksums) then
-    write (checksums_filename,'(A)') trim(cchecksums_path)
 
     if (icall_mode == 1) then
-      call dump_checksums_psp(filename=checksums_filename, noutdump=noutdump_checksum, &
+      call dump_checksums_psp(filename=cchecksums_path, noutdump=noutdump_checksum, &
         &                     jstep=jstep, myproc=myproc, ivset=ivset, ivsetsc=ivsetsc, &
         &                     nspec2g=nspec2g, zspvor=zspvor, zspdiv=zspdiv, zspscalar=zspscalar, &
         &                     append_checksums=.true.)
     else
-      call dump_checksums_psp_3a_2(filename=checksums_filename, noutdump=noutdump_checksum, &
+      call dump_checksums_psp_3a_2(filename=cchecksums_path, noutdump=noutdump_checksum, &
         &                          jstep=jstep, myproc=myproc, ivset=ivset, ivsetsc2=ivsetsc2, &
         &                          nspec2g=nspec2g, zspvor=zspvor, zspdiv=zspdiv, zspsc3a=zspsc3a, &
         &                          zspsc2=zspsc2, append_checksums=.true.)

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -20,12 +20,13 @@ program ectrans_benchmark
 !           Sam Hatfield
 !
 
-use parkind1, only: jpim, jpib, jprb, jprd
+use parkind1, only: jpim, jprb, jprd
 use oml_mod ,only : oml_max_threads
 use mpl_module
 use yomgstats, only: jpmaxstat, gstats_lstats => lstats
 use yomhook, only : dr_hook_init
 use ectrans_memory, only : allocator
+use ec_checksum_mod, only : fletcher16_hex
 
 #if USE_FIELD_API
 USE ectrans_field_api_helper, only : wrapped_fields, fields_lists, &
@@ -182,14 +183,14 @@ type(fields_lists) :: ylf
 logical :: ldump_values = .false.
 logical :: lpinning = .false.
 logical :: ldump_checksums = .false.
-character(len=256) :: checksums_filename
+character(len=1024) :: checksums_filename
 
 integer, external :: ec_mpirank
 logical :: luse_mpi = .true.
 logical :: lalloperm = .true.
 
 character(len=16)   :: cgrid = ''
-character(len=128)  :: cchecksums_path = ''
+character(len=1024) :: cchecksums_path = ''
 
 integer(kind=jpim) :: iend
 integer(kind=jpim) :: ierr
@@ -357,8 +358,20 @@ enddo
 
 nflevl = numll(mysetv)
 
-ivsetsc2(1) = iprused
 ifld = 0
+ivsetsc2(1) = 1 ! Only for callmode 2
+! The standalone 2D scalar field in callmode 2 must be assigned to a stable, decomposition-independent
+! spectral V-set. Previously this value followed iprused, which depends on the number of vertical levels
+! and on the spectral decomposition. That made the synthetic benchmark data layout change between serial
+! and MPI runs even though the logical test case was intended to be identical.
+! This showed up as checksum differences for zspsc2 between mpi0 and mpi4: the actual field being
+! transformed was the same benchmark field, but it was attached to a different V-set depending on the
+! decomposition. Since zspsc2 is a single 2D scalar field and has no vertical level distribution to mirror,
+! assigning it consistently to V-set 1 gives it a canonical owner. That makes the checksum independent of
+! execution decomposition, which is one of the invariants the checksum tests are meant to enforce.
+! In other words: this change removes decomposition metadata from the benchmark result. The checksum
+! should reflect transform output for the logical field, not where the benchmark happened to place that
+! single 2D scalar in a particular MPI layout.
 
 !===================================================================================================
 ! Setup allocation strategy
@@ -484,7 +497,25 @@ if (icall_mode == 1) then
       enddo
     enddo
   enddo
-  ivsetsc(nfld*nflevg+1) = 1
+  ivsetsc(nfld*nflevg+1) = ivset(nflevg) ! This is the extra 2D scalar field
+  ! Callmode 1 stores all scalar fields in one combined zspscalar / zgp sequence: first the nfld * nflevg 3D scalar levels,
+  ! then one extra standalone 2D scalar. With --npromatr 20, the transform processes scalar fields in blocks.
+  ! For the nfld=10, nlev=20 test, that means the last 3D scalar level and the extra 2D scalar sit exactly at the sensitive
+  ! boundary of the combined scalar ordering.
+  ! When the 2D scalar was always assigned to V-set 1, MPI decomposition could make the blocked transform order differ from
+  ! the serial order. The observed symptom was that zgp(240) and zgp(241) were swapped between mpi0 and mpi4 in the
+  ! inverse-transform checksum file, and the combined zspscalar checksum then differed after the direct transform.
+  ! The transform was not merely producing a different numeric result; the benchmark had given the extra scalar
+  ! a V-set assignment that could disturb the canonical field order under NPROMATR blocking.
+
+  ! Assigning the extra 2D scalar to ivset(nflevg) places it on the same V-set as the final 3D scalar level,
+  ! preserving the intended combined scalar ordering across serial and MPI decompositions.
+  ! This keeps callmode 1’s packed scalar array stable when field blocking is enabled, so checksum files remain
+  ! independent of execution decomposition and NPROMATR.
+
+  ! The important distinction from the callmode 2 fix is that callmode 1 needs order preservation inside a single combined
+  ! scalar array. The extra scalar is not independent in the memory/interface layout; it follows the 3D scalar levels,
+  ! so its V-set assignment must be compatible with that sequence.
 
   call allocator%allocate('zspscalar', zspscalar, [count(ivsetsc == mysetv),nspec2])
   call initialize_spectral_field(nsmax, zspscalar)
@@ -691,7 +722,7 @@ do jstep = 1, iters+iters_warmup
   if (ldump_checksums) then
     ! Remove trash at end of last block
     iend = ngptot - nproma * (ngpblks - 1)
-    write (checksums_filename,'(A)') trim(cchecksums_path)//'_inv_trans.checksums'
+    write (checksums_filename,'(A)') trim(cchecksums_path)
     if (icall_mode == 1) then
       ! Remove trash at end of last block
       zgp (iend+1:, :, ngpblks) = 0
@@ -705,7 +736,7 @@ do jstep = 1, iters+iters_warmup
       zgp2 (iend+1:, :, ngpblks) = 0
       call dump_checksums_pgp_uv_3a_2(filename=checksums_filename, noutdump=noutdump_checksum, &
                                     & jstep=jstep, myproc=myproc, nproma=nproma, ngptotg=ngptotg, &
-                                    & zgpuv=zgpuv, zgp3a=zgp3a, zgp2=zgp2)
+                                    & lscders=lscders, luvder=luvder, zgpuv=zgpuv, zgp3a=zgp3a, zgp2=zgp2)
     endif
   endif
 
@@ -768,17 +799,18 @@ do jstep = 1, iters+iters_warmup
   endif
 
   if (ldump_checksums) then
-    write (checksums_filename,'(A)') trim(cchecksums_path)//'_dir_trans.checksums'
+    write (checksums_filename,'(A)') trim(cchecksums_path)
 
     if (icall_mode == 1) then
       call dump_checksums_psp(filename=checksums_filename, noutdump=noutdump_checksum, &
         &                     jstep=jstep, myproc=myproc, ivset=ivset, ivsetsc=ivsetsc, &
-        &                     nspec2g=nspec2g, zspvor=zspvor, zspdiv=zspdiv, zspscalar=zspscalar)
+        &                     nspec2g=nspec2g, zspvor=zspvor, zspdiv=zspdiv, zspscalar=zspscalar, &
+        &                     append_checksums=.true.)
     else
       call dump_checksums_psp_3a_2(filename=checksums_filename, noutdump=noutdump_checksum, &
         &                          jstep=jstep, myproc=myproc, ivset=ivset, ivsetsc2=ivsetsc2, &
         &                          nspec2g=nspec2g, zspvor=zspvor, zspdiv=zspdiv, zspsc3a=zspsc3a, &
-        &                          zspsc2=zspsc2)
+        &                          zspsc2=zspsc2, append_checksums=.true.)
     endif
   endif
   call gstats(5,1)
@@ -1159,7 +1191,7 @@ end function
 
 function get_str_value(cname, iarg) result(value)
 
-  character(len=128) :: value
+  character(len=1024) :: value
   character(len=*), intent(in) :: cname
   integer, intent(inout) :: iarg
 
@@ -1258,7 +1290,7 @@ subroutine print_help(unit)
   write(nout, "(a)") ""
   write(nout, "(a)") "DEBUGGING"
   write(nout, "(a)") "    --dump-values             Output gridpoint fields in unformatted binary file"
-  write(nout, "(a)") "    --dump-checksums FILENAME Output CRC64 checksums of fields in text file named FILENAME"
+  write(nout, "(a)") "    --dump-checksums FILENAME Output checksums of fields in text file named FILENAME"
   write(nout, "(a)") ""
 
 end subroutine print_help
@@ -1305,7 +1337,7 @@ subroutine get_command_line_arguments(nsmax, cgrid, iters, iters_warmup, nfld, n
   integer, intent(inout) :: npromatr        ! block size for field-blocking
   integer, intent(inout) :: verbosity       ! Level of verbosity
   logical, intent(inout) :: ldump_values    ! Dump values of grid point fields for debugging
-  logical, intent(inout) :: ldump_checksums ! Dump CRC checksums
+  logical, intent(inout) :: ldump_checksums ! Dump checksums
   logical, intent(inout) :: lprint_norms    ! Calculate and print spectral norms of fields
   logical, intent(inout) :: lmeminfo        ! Show information from FIAT ec_meminfo routine at the
                                             ! end
@@ -1319,7 +1351,7 @@ subroutine get_command_line_arguments(nsmax, cgrid, iters, iters_warmup, nfld, n
                                             ! 1: pspvor, pspdiv, pspscalar, pgp
                                             ! 2: pspvor, pspdiv, pspsc3a, pspsc2, pgpuv, pgp3a, pgp2
 
-  character(len=128), intent(inout) :: cchecksums_path ! path to export checksum files
+  character(len=1024), intent(inout) :: cchecksums_path ! path to export checksum files
   logical, intent(inout) :: lalloperm                  ! keep FOUBUF & FOUBUF_IN allocated
   character(len=128) :: carg          ! Storage variable for command line arguments
   integer            :: iarg          ! Argument index
@@ -1500,6 +1532,22 @@ end subroutine initialize_2d_spectral_field
 
 !===================================================================================================
 
+function discontiguous_fletcher16_hex(field) result(checksum_hex)
+
+  real(kind=jprb), intent(in) :: field(:,:)
+  character(len=4) :: checksum_hex
+  real(kind=jprb), allocatable :: contiguous_field(:,:)
+
+  ! Although fletcher16_hex has the CONTIGUOUS attribute, it was not respected by the NVHPC 26.3 compiler.
+  ! Make an explicit contiguous copy before passing a potentially discontiguous array section.
+  allocate(contiguous_field(size(field,1), size(field,2)))
+  contiguous_field(:,:) = field(:,:)
+  checksum_hex = fletcher16_hex(contiguous_field)
+
+end function discontiguous_fletcher16_hex
+
+!===================================================================================================
+
 subroutine dump_gridpoint_field(jstep, myproc, nproma, gfld, fld, fldchar, noutdump)
 
   ! Dump a 2d field to a binary file.
@@ -1533,26 +1581,36 @@ end subroutine dump_gridpoint_field
 
 !===================================================================================================
 
-subroutine open_dump_checksums_file(filename, noutdump, jstep)
+subroutine open_dump_checksums_file(filename, noutdump, jstep, append_checksums)
 
   character(len=*),   intent(in) :: filename
   integer(kind=jpim), intent(in) :: noutdump ! unit number for output file
   integer(kind=jpim), intent(in) :: jstep
+  logical, intent(in), optional :: append_checksums
   logical :: exist
+  logical :: append
+  integer(kind=jpim), save :: last_header_jstep = -1
 
+  append = .false.
+  if (present(append_checksums)) append = append_checksums
+  if (jstep > 1) append = .true.
   exist = .false.
-  if (jstep > 1) inquire(file=trim(filename), exist=exist)
+  if (append) inquire(file=trim(filename), exist=exist)
   if (exist) then
     write(nout,*) "re-opening ",  trim(filename), noutdump
     open(noutdump, file=trim(filename), status="old", position="append", action="write")
   else
     write(nout,*) "opening ",  trim(filename), noutdump
     open(noutdump, file=trim(filename), action="write")
+    last_header_jstep = -1
   endif
 
-  write(noutdump,*) "===================="
-  write(noutdump,*) "iteration", jstep
-  write(noutdump,*) "===================="
+  if (jstep /= last_header_jstep) then
+    write(noutdump,'(a)')     "# --------------------------------------------"
+    write(noutdump,'(a, i0)') "# Iteration ", jstep
+    write(noutdump,'(a)')     "# --------------------------------------------"
+    last_header_jstep = jstep
+  endif
 
 end subroutine open_dump_checksums_file
 
@@ -1569,23 +1627,21 @@ subroutine dump_checksums_pgp(filename, noutdump,             &
   integer(kind=jpim), intent(in) :: nproma   ! size of nproma
   integer(kind=jpim), intent(in) :: ngptotg
   real(kind=jprb), intent(in) :: zgp(:,:,:)
-  integer(kind=jpib) :: icrc
   integer(kind=jpim) :: jfld
   real(kind=jprb), allocatable :: gfld(:,:)
+  character(len=4) :: checksum_hex
 
   if (myproc == 1) then
    call open_dump_checksums_file(filename, noutdump, jstep)
 
    allocate(gfld(ngptotg,1))
   endif
-
-  icrc = 0
   do jfld = 1, size(zgp, 2)
     call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
       &            pgp=zgp(:,jfld:jfld,:))
     if (myproc == 1) then
-      call crc64(gfld(:,:), int(size(gfld(:,:)) * kind(gfld), 8), icrc)
-      write(noutdump, '(a," (",i0,") = ",z16.16)') "zgp", jfld, icrc
+      checksum_hex = fletcher16_hex(gfld(:,:))
+      write(noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp", jfld
     endif
   enddo
 
@@ -1600,8 +1656,8 @@ end subroutine dump_checksums_pgp
 !===================================================================================================
 
 subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
-                        & jstep, myproc, nproma, ngptotg, &
-                        &  zgpuv, zgp3a, zgp2)
+                        & jstep, myproc, nproma, ngptotg, lscders, luvder, &
+                        & zgpuv, zgp3a, zgp2)
 
   character(len=*),   intent(in) :: filename
   integer(kind=jpim), intent(in) :: noutdump ! unit number for output file
@@ -1609,52 +1665,118 @@ subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
   integer(kind=jpim), intent(in) :: myproc   ! mpi rank
   integer(kind=jpim), intent(in) :: nproma   ! size of nproma
   integer(kind=jpim), intent(in) :: ngptotg
+  logical, intent(in) :: lscders
+  logical, intent(in) :: luvder
   real(kind=jprb), intent(in) :: zgpuv(:,:,:,:)
   real(kind=jprb), intent(in) :: zgp3a(:,:,:,:)
   real(kind=jprb), intent(in) :: zgp2(:,:,:)
 
-  integer(kind=jpib) :: icrc
   integer(kind=jpim) :: jlev, jfld
+  integer(kind=jpim) :: base_uv_fields, base_3d_scalar_fields, base_2d_scalar_fields
   real(kind=jprb), allocatable :: gfld(:,:)
+  character(len=4) :: checksum_hex
 
   if (myproc == 1) then
     call open_dump_checksums_file(filename, noutdump, jstep)
     allocate(gfld(ngptotg,1))
   endif
 
-  icrc = 0
-  do jfld = 1, size(zgpuv, 3)
+  base_uv_fields = size(zgpuv, 3)
+  if (luvder) base_uv_fields = base_uv_fields - 2
+  base_3d_scalar_fields = size(zgp3a, 3)
+  base_2d_scalar_fields = size(zgp2, 2)
+  if (lscders) then
+    base_3d_scalar_fields = base_3d_scalar_fields / 3
+    base_2d_scalar_fields = base_2d_scalar_fields / 3
+  endif
+
+  do jfld = 1, base_uv_fields
     do jlev = 1, size(zgpuv, 2)
       call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
         &            pgp=zgpuv(:,jlev:jlev,jfld,:))
       if (myproc == 1) then
-        call crc64(gfld(:,:), int(size(gfld(:,:)) * kind(gfld), 8), icrc)
-        write(noutdump, '(a," (",i0,", ",i0,") = ",z16.16)') "zgpuv", jlev, jfld, icrc
+        checksum_hex = fletcher16_hex(gfld(:,:))
+        write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgpuv", jlev, jfld
       endif
     enddo
   enddo
 
-  icrc = 0
-  do jfld = 1, size(zgp3a, 3)
+  do jfld = 1, base_3d_scalar_fields
     do jlev = 1, size(zgp3a, 2)
       call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
         &            pgp=zgp3a(:,jlev:jlev,jfld,:))
       if (myproc == 1) then
-        call crc64(gfld(:,:), int(size(gfld(:,:)) * kind(gfld), 8), icrc)
-        write(noutdump, '(a," (",i0,", ",i0,") = ",z16.16)') "zgp3a", jlev, jfld, icrc
+        checksum_hex = fletcher16_hex(gfld(:,:))
+        write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgp3a", jlev, jfld
       endif
     enddo
   enddo
 
-  icrc = 0
-  do jfld = 1, size(zgp2, 2)
+  do jfld = 1, base_2d_scalar_fields
     call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
       &            pgp=zgp2(:,jfld:jfld,:))
     if (myproc == 1) then
-      call crc64(gfld(:,:), int(size(gfld(:,:)) * kind(gfld), 8), icrc)
-      write(noutdump, '(a," (",i0,") = ",z16.16)') "zgp2", jfld, icrc
+      checksum_hex = fletcher16_hex(gfld(:,:))
+      write(noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp2", jfld
     endif
   enddo
+
+  if (lscders) then
+    do jfld = base_3d_scalar_fields + 1, 2 * base_3d_scalar_fields
+      do jlev = 1, size(zgp3a, 2)
+        call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
+          &            pgp=zgp3a(:,jlev:jlev,jfld,:))
+        if (myproc == 1) then
+          checksum_hex = fletcher16_hex(gfld(:,:))
+          write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgp3a", jlev, jfld
+        endif
+      enddo
+    enddo
+
+    do jfld = base_2d_scalar_fields + 1, 2 * base_2d_scalar_fields
+      call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
+        &            pgp=zgp2(:,jfld:jfld,:))
+      if (myproc == 1) then
+        checksum_hex = fletcher16_hex(gfld(:,:))
+        write(noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp2", jfld
+      endif
+    enddo
+  endif
+
+  if (luvder) then
+    do jfld = base_uv_fields + 1, size(zgpuv, 3)
+      do jlev = 1, size(zgpuv, 2)
+        call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
+          &            pgp=zgpuv(:,jlev:jlev,jfld,:))
+        if (myproc == 1) then
+          checksum_hex = fletcher16_hex(gfld(:,:))
+          write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgpuv", jlev, jfld
+        endif
+      enddo
+    enddo
+  endif
+
+  if (lscders) then
+    do jfld = 2 * base_3d_scalar_fields + 1, 3 * base_3d_scalar_fields
+      do jlev = 1, size(zgp3a, 2)
+        call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
+          &            pgp=zgp3a(:,jlev:jlev,jfld,:))
+        if (myproc == 1) then
+          checksum_hex = fletcher16_hex(gfld(:,:))
+          write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgp3a", jlev, jfld
+        endif
+      enddo
+    enddo
+
+    do jfld = 2 * base_2d_scalar_fields + 1, 3 * base_2d_scalar_fields
+      call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
+        &            pgp=zgp2(:,jfld:jfld,:))
+      if (myproc == 1) then
+        checksum_hex = fletcher16_hex(gfld(:,:))
+        write(noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp2", jfld
+      endif
+    enddo
+  endif
 
   if (myproc == 1) then
     write(nout,*) "close ", noutdump
@@ -1669,7 +1791,7 @@ end subroutine dump_checksums_pgp_uv_3a_2
 subroutine dump_checksums_psp(filename, noutdump,       &
                         & jstep, myproc,  nspec2g,      &
                         & ivset, ivsetsc,               &
-                        & zspvor, zspdiv, zspscalar)
+                        & zspvor, zspdiv, zspscalar, append_checksums)
   character(len=*),   intent(in) :: filename
   integer(kind=jpim), intent(in) :: noutdump ! unit number for output file
   integer(kind=jpim), intent(in) :: jstep    ! time step
@@ -1680,12 +1802,13 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   real(kind=jprb), intent(in) :: zspvor(:,:)
   real(kind=jprb), intent(in) :: zspdiv(:,:)
   real(kind=jprb), intent(in) :: zspscalar(:,:)
-  integer(kind=jpim) :: numfld
-  integer(kind=jpib) :: icrc
+  logical, intent(in), optional :: append_checksums
+  integer(kind=jpim) :: numfld, numscfld, nlev_checksum, jfld, ifirst, ilast
   real(kind=jprb), allocatable :: gspfld(:,:)
+  character(len=4) :: checksum_hex
 
   if (myproc == 1) then
-    call open_dump_checksums_file(filename, noutdump, jstep)
+    call open_dump_checksums_file(filename, noutdump, jstep, append_checksums)
     allocate(gspfld(max(size(ivset), size(ivsetsc)), nspec2g))
   endif
 
@@ -1693,9 +1816,8 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
       &            kvset=ivset, pspec=zspvor)
-    icrc = 0
-    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
-    write(noutdump, '(a," = ",z16.16)') "zspvor", icrc
+    checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
+    write(noutdump, '(a," # ",a)') checksum_hex, "zspvor"
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspvor)
   endif
@@ -1703,9 +1825,8 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
       &            kvset=ivset, pspec=zspdiv)
-    icrc = 0
-    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
-    write(noutdump, '(a," = ",z16.16)') "zspdiv", icrc
+    checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
+    write(noutdump, '(a," # ",a)') checksum_hex, "zspdiv"
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspdiv)
   endif
@@ -1714,9 +1835,16 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
       &            kvset=ivsetsc, pspec=zspscalar)
-    icrc = 0
-    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
-    write(noutdump, '(a," = ",z16.16)') "zspscalar", icrc
+    nlev_checksum = size(ivset)
+    numscfld = (size(ivsetsc) - 1) / nlev_checksum
+    do jfld = 1, numscfld
+      ifirst = (jfld - 1) * nlev_checksum + 1
+      ilast = jfld * nlev_checksum
+      checksum_hex = discontiguous_fletcher16_hex(gspfld(ifirst:ilast,:))
+      write(noutdump, '(a," # ",a,"(",i0,")")') checksum_hex, "zspscalar", jfld
+    enddo
+    checksum_hex = discontiguous_fletcher16_hex(gspfld(numscfld*nlev_checksum+1:numscfld*nlev_checksum+1,:))
+    write(noutdump, '(a," # ",a,"(",i0,")")') checksum_hex, "zspscalar", numscfld + 1
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivsetsc, pspec=zspscalar)
   endif
@@ -1735,7 +1863,7 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
                         & jstep, myproc, nspec2g, &
                         & ivset, ivsetsc2,              &
                         & zspvor, zspdiv,               &
-                        & zspsc3a, zspsc2)
+                        & zspsc3a, zspsc2, append_checksums)
   character(len=*),   intent(in) :: filename
   integer(kind=jpim), intent(in) :: noutdump ! unit number for output file
   integer(kind=jpim), intent(in) :: jstep    ! time step
@@ -1747,13 +1875,14 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   real(kind=jprb), intent(in) :: zspdiv(:,:)
   real(kind=jprb), intent(in) :: zspsc3a(:,:,:)
   real(kind=jprb), intent(in) :: zspsc2(:,:)
+  logical, intent(in), optional :: append_checksums
 
   integer(kind=jpim) :: numfld, jfld
-  integer(kind=jpib) :: icrc
   real(kind=jprb), allocatable :: gspfld(:,:)
+  character(len=4) :: checksum_hex
 
   if (myproc == 1) then
-    call open_dump_checksums_file(filename, noutdump, jstep)
+    call open_dump_checksums_file(filename, noutdump, jstep, append_checksums)
     allocate(gspfld(max(size(ivset), 1), nspec2g)) ! size(ivsetsc2) is always 1
   endif
 
@@ -1761,9 +1890,8 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
       &            kvset=ivset, pspec=zspvor)
-    icrc = 0
-    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
-    write(noutdump, '(a," = ",z16.16)') "zspvor", icrc
+    checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
+    write(noutdump, '(a," # ",a)') checksum_hex, "zspvor"
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspvor)
   endif
@@ -1771,9 +1899,8 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
       &            kvset=ivset, pspec=zspdiv)
-    icrc = 0
-    call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
-    write(noutdump, '(a," = ",z16.16)') "zspdiv", icrc
+    checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
+    write(noutdump, '(a," # ",a)') checksum_hex, "zspdiv"
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspdiv)
   endif
@@ -1782,9 +1909,8 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
     if (myproc == 1) then
       call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
         &            kvset=ivset, pspec=zspsc3a(:,:,jfld))
-      icrc = 0
-      call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
-      write(noutdump, '(a,"(",i0,") = ",z16.16)') "zspsc3a", jfld, icrc
+      checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
+      write(noutdump, '(a," # ",a,"(",i0,")")') checksum_hex, "zspsc3a", jfld
     else
       call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspsc3a(:,:,jfld))
     endif
@@ -1792,9 +1918,8 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
 
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc2, pspec=zspsc2)
-    icrc = 0
-    call crc64(gspfld(1,:), int(size(gspfld(1,:)) * kind(gspfld), 8), icrc)
-    write(noutdump, '(a," = ",z16.16)') "zspsc2", icrc
+    checksum_hex = discontiguous_fletcher16_hex(gspfld(1:1,:))
+    write(noutdump, '(a," # ",a)') checksum_hex, "zspsc2"
   else
     call gath_spec(kfgathg=1, kto=[1], kvset=ivsetsc2, pspec=zspsc2)
   endif

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -242,7 +242,14 @@ call get_command_line_arguments(nsmax, cgrid, iters, iters_warmup, nfld, nlev, l
   &                             ldump_values, lprint_norms, lmeminfo, nprtrv, nprtrw, ncheck, &
   &                             lpinning, lfield_api, icall_mode, ldump_checksums, iters_checksums, &
   &                             cchecksums_path, lalloperm)
-if (iters_checksums < 0) iters_checksums = iters_warmup
+if (iters_checksums < 0) then
+  if (iters_warmup > 0) then
+    iters_checksums = iters_warmup
+  else
+    iters_checksums = iters
+  endif
+endif
+
 if (cgrid == '') cgrid = cubic_octahedral_gaussian_grid(nsmax)
 call parse_grid(cgrid, ndgl, nloen)
 nflevg = nlev
@@ -1237,8 +1244,8 @@ subroutine print_help(unit)
     & iterations (default = 10)"
   write(nout, "(a)") "    --niter-warmup      Number of warm up iterations,&
     & for which timing statistics should be ignored (default = 3)"
-  write(nout, "(a)") "    --niter-checksums  Number of iterations for which checksum output is&
-    & written, counting warmup iterations too (default = --niter-warmup)"
+  write(nout, "(a)") "    --niter-checksums   Number of iterations for which checksum output is&
+    & written, counting warmup iterations too (default = --niter-warmup > 0 ? --niter-warmup : --niter)"
   write(nout, "(a)") "    -f, --nfld NFLD     Number of scalar fields (default = 1)"
   write(nout, "(a)") "    -l, --nlev NLEV     Number of vertical levels (default = 1)"
   write(nout, "(a)") "    --vordiv            Also transform vorticity-divergence to wind"
@@ -1262,13 +1269,13 @@ subroutine print_help(unit)
   write(nout, "(a)") "    --no-pinning        Disable memory-pinning (a.k.a. page-locked memory) &
    & to allocate fields for GPU version"
   write(nout, "(a)") "    --field-api         Use the field api interface of ecTrans"
-  write(nout, "(a)") "    --callmode          The call mode for INV_TRANS and DIR_TRANS (1 or 2)"
+  write(nout, "(a)") "    --callmode          The call mode for INV_TRANS and DIR_TRANS (1 or 2; default = 2)"
   write(nout, "(a)") "                        Call mode 1 uses arrays PSPVOR, PSPDIV, PSPSCALAR and&
    & PGP"
   write(nout, "(a)") "                        Call mode 2 uses arrays PSPVOR, PSPDIV, PSPSC3A,&
    & PSPSC3B, PSPSC2, PGPUV, PGP3A, PGP3B, PGP2"
   write(nout, "(a)") "                        See&
-   & https://sites.ecmwf.int/docs/ectrans/page/api.html for more information (default  = 2)"
+   & https://sites.ecmwf.int/docs/ectrans/page/api.html for more information"
   write(nout, "(a)") "    --deallocate-foubuf-temps Enable deallocation of temporary Fourier-space&
    & buffers (default = off, when enabled equivalent to LALLOPERM=.FALSE.)"
   write(nout, "(a)") ""

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -370,20 +370,8 @@ enddo
 
 nflevl = numll(mysetv)
 
+ivsetsc2(1) = iprused
 ifld = 0
-ivsetsc2(1) = 1 ! Only for callmode 2
-! The standalone 2D scalar field in callmode 2 must be assigned to a stable, decomposition-independent
-! spectral V-set. Previously this value followed iprused, which depends on the number of vertical levels
-! and on the spectral decomposition. That made the synthetic benchmark data layout change between serial
-! and MPI runs even though the logical test case was intended to be identical.
-! This showed up as checksum differences for zspsc2 between mpi0 and mpi4: the actual field being
-! transformed was the same benchmark field, but it was attached to a different V-set depending on the
-! decomposition. Since zspsc2 is a single 2D scalar field and has no vertical level distribution to mirror,
-! assigning it consistently to V-set 1 gives it a canonical owner. That makes the checksum independent of
-! execution decomposition, which is one of the invariants the checksum tests are meant to enforce.
-! In other words: this change removes decomposition metadata from the benchmark result. The checksum
-! should reflect transform output for the logical field, not where the benchmark happened to place that
-! single 2D scalar in a particular MPI layout.
 
 !===================================================================================================
 ! Setup allocation strategy
@@ -509,25 +497,7 @@ if (icall_mode == 1) then
       enddo
     enddo
   enddo
-  ivsetsc(nfld*nflevg+1) = ivset(nflevg) ! This is the extra 2D scalar field
-  ! Callmode 1 stores all scalar fields in one combined zspscalar / zgp sequence: first the nfld * nflevg 3D scalar levels,
-  ! then one extra standalone 2D scalar. With --npromatr 20, the transform processes scalar fields in blocks.
-  ! For the nfld=10, nlev=20 test, that means the last 3D scalar level and the extra 2D scalar sit exactly at the sensitive
-  ! boundary of the combined scalar ordering.
-  ! When the 2D scalar was always assigned to V-set 1, MPI decomposition could make the blocked transform order differ from
-  ! the serial order. The observed symptom was that zgp(240) and zgp(241) were swapped between mpi0 and mpi4 in the
-  ! inverse-transform checksum file, and the combined zspscalar checksum then differed after the direct transform.
-  ! The transform was not merely producing a different numeric result; the benchmark had given the extra scalar
-  ! a V-set assignment that could disturb the canonical field order under NPROMATR blocking.
-
-  ! Assigning the extra 2D scalar to ivset(nflevg) places it on the same V-set as the final 3D scalar level,
-  ! preserving the intended combined scalar ordering across serial and MPI decompositions.
-  ! This keeps callmode 1’s packed scalar array stable when field blocking is enabled, so checksum files remain
-  ! independent of execution decomposition and NPROMATR.
-
-  ! The important distinction from the callmode 2 fix is that callmode 1 needs order preservation inside a single combined
-  ! scalar array. The extra scalar is not independent in the memory/interface layout; it follows the 3D scalar levels,
-  ! so its V-set assignment must be compatible with that sequence.
+  ivsetsc(nfld*nflevg+1) = 1
 
   call allocator%allocate('zspscalar', zspscalar, [count(ivsetsc == mysetv),nspec2])
   call initialize_spectral_field(nsmax, zspscalar)

--- a/src/programs/ectrans-benchmark.F90
+++ b/src/programs/ectrans-benchmark.F90
@@ -50,6 +50,16 @@ integer(kind=jpim), parameter :: nout     = 6 ! Unit number for STDOUT
 integer(kind=jpim), parameter :: noutdump = 7 ! Unit number for field output
 integer(kind=jpim), parameter :: noutdump_checksum = 8 ! Unit number for dump_checksum
 
+type checksum_run_type
+  character(len=4) :: checksum = ""
+  character(len=16) :: label = ""
+  character(len=16) :: description = ""
+  integer(kind=jpim) :: first_indices(2) = 0
+  integer(kind=jpim) :: last_indices(2) = 0
+  integer(kind=jpim) :: num_indices = 0
+  integer(kind=jpim) :: count = 0
+end type checksum_run_type
+
 ! Default parameters
 integer(kind=jpim) :: iters   = 10  ! Number of iterations for transform test
 integer(kind=jpim) :: nfld    = 1   ! Number of 3D scalar fields
@@ -726,7 +736,9 @@ do jstep = 1, iters+iters_warmup
       zgp (iend+1:, :, ngpblks) = 0
       call dump_checksums_pgp(filename=cchecksums_path, noutdump=noutdump_checksum, &
                             & jstep=jstep, myproc=myproc, nproma=nproma, ngptotg=ngptotg, &
-                            & zgp=zgp)
+                            & knlev=nflevg, kuv_fields=inum_wind_fields, &
+                            & k3d_fields=inum_sc_3d_fields, k2d_fields=inum_sc_2d_fields, &
+                            & lscders=lscders, luvder=luvder, zgp=zgp)
     else
       ! Remove trash at end of last block
       zgpuv (iend+1:, :, :, ngpblks) = 0
@@ -1545,6 +1557,113 @@ end function discontiguous_fletcher16_hex
 
 !===================================================================================================
 
+function format_checksum_location(first_indices, last_indices, num_indices) result(location)
+
+  integer(kind=jpim), intent(in) :: first_indices(2)
+  integer(kind=jpim), intent(in) :: last_indices(2)
+  integer(kind=jpim), intent(in) :: num_indices
+  character(len=32) :: location
+
+  location = ""
+  select case (num_indices)
+    case (0)
+    case (1)
+      if (first_indices(1) == last_indices(1)) then
+        write(location, '("(",i0,")")') first_indices(1)
+      else
+        write(location, '("(",i0,"-",i0,")")') first_indices(1), last_indices(1)
+      endif
+    case (2)
+      if (first_indices(1) == last_indices(1) .and. first_indices(2) == last_indices(2)) then
+        write(location, '("(",i0,", ",i0,")")') first_indices(1), first_indices(2)
+      else if (first_indices(1) == last_indices(1)) then
+        write(location, '("(",i0,", ",i0,"-",i0,")")') &
+          & first_indices(1), first_indices(2), last_indices(2)
+      else if (first_indices(2) == last_indices(2)) then
+        write(location, '("(",i0,"-",i0,", ",i0,")")') &
+          & first_indices(1), last_indices(1), first_indices(2)
+      else
+        write(location, '("(",i0,"-",i0,", ",i0,"-",i0,")")') &
+          & first_indices(1), last_indices(1), first_indices(2), last_indices(2)
+      endif
+    case default
+      call abor1('format_checksum_location supports at most two indices')
+  end select
+
+end function format_checksum_location
+
+!===================================================================================================
+
+subroutine flush_checksum_run(noutdump, run)
+
+  integer(kind=jpim), intent(in) :: noutdump
+  type(checksum_run_type), intent(inout) :: run
+  character(len=32) :: location
+  character(len=24) :: label_and_location
+
+  if (run%count == 0) return
+
+  location = format_checksum_location(run%first_indices, run%last_indices, run%num_indices)
+  if (location == "") then
+    write(noutdump, '(a,1x,i4," # ",a)') run%checksum, run%count, trim(run%label)
+  else if (run%description == "") then
+    write(noutdump, '(a,1x,i4," # ",a,1x,a)') &
+      & run%checksum, run%count, trim(run%label), trim(location)
+  else
+    label_and_location = trim(run%label) // " " // trim(location)
+    write(noutdump, '(a,1x,i4," # ",a,1x,a)') &
+      & run%checksum, run%count, label_and_location, trim(run%description)
+  endif
+
+  run%checksum = ""
+  run%label = ""
+  run%description = ""
+  run%first_indices = 0
+  run%last_indices = 0
+  run%num_indices = 0
+  run%count = 0
+
+end subroutine flush_checksum_run
+
+!===================================================================================================
+
+subroutine append_checksum(noutdump, run, checksum, label, indices, description)
+
+  integer(kind=jpim), intent(in) :: noutdump
+  type(checksum_run_type), intent(inout) :: run
+  character(len=*), intent(in) :: checksum
+  character(len=*), intent(in) :: label
+  integer(kind=jpim), intent(in), optional :: indices(:)
+  character(len=*), intent(in), optional :: description
+  character(len=16) :: run_description
+
+  run_description = ""
+  if (present(description)) run_description = description
+  if (present(indices)) then
+    if (size(indices) > 2) call abor1('append_checksum supports at most two indices')
+  endif
+
+  if (run%count > 0) then
+    if (checksum /= run%checksum .or. label /= trim(run%label) .or. &
+      & run_description /= trim(run%description)) call flush_checksum_run(noutdump, run)
+  endif
+
+  if (run%count == 0) then
+    run%checksum = checksum
+    run%label = label
+    run%description = run_description
+    if (present(indices)) then
+      run%first_indices(1:size(indices)) = indices
+      run%num_indices = size(indices)
+    endif
+  endif
+  if (present(indices)) run%last_indices(1:size(indices)) = indices
+  run%count = run%count + 1
+
+end subroutine append_checksum
+
+!===================================================================================================
+
 subroutine dump_gridpoint_field(jstep, myproc, nproma, gfld, fld, fldchar, noutdump)
 
   ! Dump a 2d field to a binary file.
@@ -1615,7 +1734,8 @@ end subroutine open_dump_checksums_file
 
 subroutine dump_checksums_pgp(filename, noutdump,             &
                             & jstep, myproc, nproma, ngptotg, &
-                            & zgp)
+                            & knlev, kuv_fields, k3d_fields, k2d_fields, &
+                            & lscders, luvder, zgp)
 
   character(len=*),   intent(in) :: filename
   integer(kind=jpim), intent(in) :: noutdump ! unit number for output file
@@ -1623,10 +1743,36 @@ subroutine dump_checksums_pgp(filename, noutdump,             &
   integer(kind=jpim), intent(in) :: myproc   ! mpi rank
   integer(kind=jpim), intent(in) :: nproma   ! size of nproma
   integer(kind=jpim), intent(in) :: ngptotg
+  integer(kind=jpim), intent(in) :: knlev
+  integer(kind=jpim), intent(in) :: kuv_fields
+  integer(kind=jpim), intent(in) :: k3d_fields
+  integer(kind=jpim), intent(in) :: k2d_fields
+  logical, intent(in) :: lscders
+  logical, intent(in) :: luvder
   real(kind=jprb), intent(in) :: zgp(:,:,:)
   integer(kind=jpim) :: jfld
+  integer(kind=jpim) :: base_uv_fields, base_3d_scalar_fields, base_2d_scalar_fields
+  integer(kind=jpim) :: base_uv_size, uv_derivative_size, scalar_group_size, field_offset, scalar_group
+  logical :: checksum_appended
   real(kind=jprb), allocatable :: gfld(:,:)
   character(len=4) :: checksum_hex
+  character(len=16) :: field_description
+  type(checksum_run_type) :: checksum_run
+
+  base_uv_fields = kuv_fields
+  if (luvder) base_uv_fields = base_uv_fields - 2
+  base_3d_scalar_fields = k3d_fields
+  base_2d_scalar_fields = k2d_fields
+  if (lscders) then
+    base_3d_scalar_fields = base_3d_scalar_fields / 3
+    base_2d_scalar_fields = base_2d_scalar_fields / 3
+  endif
+  base_uv_size = knlev * base_uv_fields
+  uv_derivative_size = knlev * (kuv_fields - base_uv_fields)
+  scalar_group_size = knlev * base_3d_scalar_fields + base_2d_scalar_fields
+  if (size(zgp, 2) /= knlev * kuv_fields + knlev * k3d_fields + k2d_fields) then
+    call abor1('dump_checksums_pgp: inconsistent flattened grid-point field layout')
+  endif
 
   if (myproc == 1) then
    call open_dump_checksums_file(filename, noutdump, jstep)
@@ -1638,11 +1784,71 @@ subroutine dump_checksums_pgp(filename, noutdump,             &
       &            pgp=zgp(:,jfld:jfld,:))
     if (myproc == 1) then
       checksum_hex = fletcher16_hex(gfld(:,:))
-      write(noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp", jfld
+      field_offset = jfld
+      if (field_offset <= base_uv_size) then
+        if (base_uv_fields == 4) then
+          select case ((field_offset - 1) / knlev + 1)
+            case (1); field_description = "vorticity"
+            case (2); field_description = "divergence"
+            case (3); field_description = "u"
+            case (4); field_description = "v"
+          end select
+        else
+          if (field_offset <= knlev) then
+            field_description = "u"
+          else
+            field_description = "v"
+          endif
+        endif
+        call append_checksum(noutdump, checksum_run, checksum_hex, "zgp", [jfld], field_description)
+      else
+        field_offset = field_offset - base_uv_size
+        scalar_group = 0
+        checksum_appended = .false.
+        if (field_offset > scalar_group_size) then
+          field_offset = field_offset - scalar_group_size
+          if (lscders) then
+            scalar_group = 1
+            if (field_offset > scalar_group_size) then
+              field_offset = field_offset - scalar_group_size
+              scalar_group = 2
+            endif
+          endif
+          if (scalar_group /= 1 .and. luvder .and. field_offset <= uv_derivative_size) then
+            if (field_offset <= knlev) then
+              field_description = "u-ew"
+            else
+              field_description = "v-ew"
+            endif
+            call append_checksum(noutdump, checksum_run, checksum_hex, "zgp", [jfld], field_description)
+            checksum_appended = .true.
+          else if (scalar_group == 2 .and. luvder) then
+            field_offset = field_offset - uv_derivative_size
+          endif
+        endif
+        if (.not. checksum_appended) then
+          if (field_offset <= knlev * base_3d_scalar_fields) then
+            select case (scalar_group)
+              case (0); field_description = "scalar-3d"
+              case (1); field_description = "scalar-3d-ns"
+              case (2); field_description = "scalar-3d-ew"
+            end select
+            call append_checksum(noutdump, checksum_run, checksum_hex, "zgp", [jfld], field_description)
+          else
+            select case (scalar_group)
+              case (0); field_description = "scalar-2d"
+              case (1); field_description = "scalar-2d-ns"
+              case (2); field_description = "scalar-2d-ew"
+            end select
+            call append_checksum(noutdump, checksum_run, checksum_hex, "zgp", [jfld], field_description)
+          endif
+        endif
+      endif
     endif
   enddo
 
   if (myproc == 1) then
+    call flush_checksum_run(noutdump, checksum_run)
     write(nout,*) "close ", noutdump
     close(noutdump)
     if (allocated(gfld)) deallocate(gfld)
@@ -1672,6 +1878,8 @@ subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
   integer(kind=jpim) :: base_uv_fields, base_3d_scalar_fields, base_2d_scalar_fields
   real(kind=jprb), allocatable :: gfld(:,:)
   character(len=4) :: checksum_hex
+  character(len=16) :: field_description
+  type(checksum_run_type) :: checksum_run
 
   if (myproc == 1) then
     call open_dump_checksums_file(filename, noutdump, jstep)
@@ -1688,12 +1896,26 @@ subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
   endif
 
   do jfld = 1, base_uv_fields
+    if (base_uv_fields == 4) then
+      select case (jfld)
+        case (1); field_description = "vorticity"
+        case (2); field_description = "divergence"
+        case (3); field_description = "u"
+        case (4); field_description = "v"
+      end select
+    else
+      if (jfld == 1) then
+        field_description = "u"
+      else
+        field_description = "v"
+      endif
+    endif
     do jlev = 1, size(zgpuv, 2)
       call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
         &            pgp=zgpuv(:,jlev:jlev,jfld,:))
       if (myproc == 1) then
         checksum_hex = fletcher16_hex(gfld(:,:))
-        write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgpuv", jlev, jfld
+        call append_checksum(noutdump, checksum_run, checksum_hex, "zgpuv", [jlev, jfld], field_description)
       endif
     enddo
   enddo
@@ -1704,7 +1926,7 @@ subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
         &            pgp=zgp3a(:,jlev:jlev,jfld,:))
       if (myproc == 1) then
         checksum_hex = fletcher16_hex(gfld(:,:))
-        write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgp3a", jlev, jfld
+        call append_checksum(noutdump, checksum_run, checksum_hex, "zgp3a", [jlev, jfld], "scalar-3d")
       endif
     enddo
   enddo
@@ -1714,7 +1936,7 @@ subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
       &            pgp=zgp2(:,jfld:jfld,:))
     if (myproc == 1) then
       checksum_hex = fletcher16_hex(gfld(:,:))
-      write(noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp2", jfld
+      call append_checksum(noutdump, checksum_run, checksum_hex, "zgp2", [jfld], "scalar-2d")
     endif
   enddo
 
@@ -1725,7 +1947,7 @@ subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
           &            pgp=zgp3a(:,jlev:jlev,jfld,:))
         if (myproc == 1) then
           checksum_hex = fletcher16_hex(gfld(:,:))
-          write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgp3a", jlev, jfld
+          call append_checksum(noutdump, checksum_run, checksum_hex, "zgp3a", [jlev, jfld], "scalar-3d-ns")
         endif
       enddo
     enddo
@@ -1735,19 +1957,24 @@ subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
         &            pgp=zgp2(:,jfld:jfld,:))
       if (myproc == 1) then
         checksum_hex = fletcher16_hex(gfld(:,:))
-        write(noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp2", jfld
+        call append_checksum(noutdump, checksum_run, checksum_hex, "zgp2", [jfld], "scalar-2d-ns")
       endif
     enddo
   endif
 
   if (luvder) then
     do jfld = base_uv_fields + 1, size(zgpuv, 3)
+      if (jfld == base_uv_fields + 1) then
+        field_description = "u-ew"
+      else
+        field_description = "v-ew"
+      endif
       do jlev = 1, size(zgpuv, 2)
         call gath_grid(pgpg=gfld, kproma=nproma, kfgathg=1, kto=(/1/), kresol=1, &
           &            pgp=zgpuv(:,jlev:jlev,jfld,:))
         if (myproc == 1) then
           checksum_hex = fletcher16_hex(gfld(:,:))
-          write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgpuv", jlev, jfld
+          call append_checksum(noutdump, checksum_run, checksum_hex, "zgpuv", [jlev, jfld], field_description)
         endif
       enddo
     enddo
@@ -1760,7 +1987,7 @@ subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
           &            pgp=zgp3a(:,jlev:jlev,jfld,:))
         if (myproc == 1) then
           checksum_hex = fletcher16_hex(gfld(:,:))
-          write(noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgp3a", jlev, jfld
+          call append_checksum(noutdump, checksum_run, checksum_hex, "zgp3a", [jlev, jfld], "scalar-3d-ew")
         endif
       enddo
     enddo
@@ -1770,12 +1997,13 @@ subroutine dump_checksums_pgp_uv_3a_2(filename, noutdump,                      &
         &            pgp=zgp2(:,jfld:jfld,:))
       if (myproc == 1) then
         checksum_hex = fletcher16_hex(gfld(:,:))
-        write(noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp2", jfld
+        call append_checksum(noutdump, checksum_run, checksum_hex, "zgp2", [jfld], "scalar-2d-ew")
       endif
     enddo
   endif
 
   if (myproc == 1) then
+    call flush_checksum_run(noutdump, checksum_run)
     write(nout,*) "close ", noutdump
     close(noutdump)
     if (allocated(gfld)) deallocate(gfld)
@@ -1803,6 +2031,7 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   integer(kind=jpim) :: numfld, numscfld, nlev_checksum, jfld, ifirst, ilast
   real(kind=jprb), allocatable :: gspfld(:,:)
   character(len=4) :: checksum_hex
+  type(checksum_run_type) :: checksum_run
 
   if (myproc == 1) then
     call open_dump_checksums_file(filename, noutdump, jstep, append_checksums)
@@ -1813,8 +2042,10 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
       &            kvset=ivset, pspec=zspvor)
-    checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
-    write(noutdump, '(a," # ",a)') checksum_hex, "zspvor"
+    do jfld = 1, numfld
+      checksum_hex = discontiguous_fletcher16_hex(gspfld(jfld:jfld,:))
+      call append_checksum(noutdump, checksum_run, checksum_hex, "zspvor", [jfld], "vorticity")
+    enddo
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspvor)
   endif
@@ -1822,8 +2053,10 @@ subroutine dump_checksums_psp(filename, noutdump,       &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
       &            kvset=ivset, pspec=zspdiv)
-    checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
-    write(noutdump, '(a," # ",a)') checksum_hex, "zspdiv"
+    do jfld = 1, numfld
+      checksum_hex = discontiguous_fletcher16_hex(gspfld(jfld:jfld,:))
+      call append_checksum(noutdump, checksum_run, checksum_hex, "zspdiv", [jfld], "divergence")
+    enddo
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspdiv)
   endif
@@ -1838,15 +2071,16 @@ subroutine dump_checksums_psp(filename, noutdump,       &
       ifirst = (jfld - 1) * nlev_checksum + 1
       ilast = jfld * nlev_checksum
       checksum_hex = discontiguous_fletcher16_hex(gspfld(ifirst:ilast,:))
-      write(noutdump, '(a," # ",a,"(",i0,")")') checksum_hex, "zspscalar", jfld
+      call append_checksum(noutdump, checksum_run, checksum_hex, "zspscalar", [jfld], "scalar-3d")
     enddo
     checksum_hex = discontiguous_fletcher16_hex(gspfld(numscfld*nlev_checksum+1:numscfld*nlev_checksum+1,:))
-    write(noutdump, '(a," # ",a,"(",i0,")")') checksum_hex, "zspscalar", numscfld + 1
+    call append_checksum(noutdump, checksum_run, checksum_hex, "zspscalar", [numscfld + 1], "scalar-2d")
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivsetsc, pspec=zspscalar)
   endif
 
   if (myproc == 1) then
+    call flush_checksum_run(noutdump, checksum_run)
     write(nout,*) "close ", noutdump
     close(noutdump)
     if (allocated(gspfld)) deallocate(gspfld)
@@ -1877,6 +2111,7 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   integer(kind=jpim) :: numfld, jfld
   real(kind=jprb), allocatable :: gspfld(:,:)
   character(len=4) :: checksum_hex
+  type(checksum_run_type) :: checksum_run
 
   if (myproc == 1) then
     call open_dump_checksums_file(filename, noutdump, jstep, append_checksums)
@@ -1887,8 +2122,10 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
       &            kvset=ivset, pspec=zspvor)
-    checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
-    write(noutdump, '(a," # ",a)') checksum_hex, "zspvor"
+    do jfld = 1, numfld
+      checksum_hex = discontiguous_fletcher16_hex(gspfld(jfld:jfld,:))
+      call append_checksum(noutdump, checksum_run, checksum_hex, "zspvor", [jfld], "vorticity")
+    enddo
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspvor)
   endif
@@ -1896,8 +2133,10 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
       &            kvset=ivset, pspec=zspdiv)
-    checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
-    write(noutdump, '(a," # ",a)') checksum_hex, "zspdiv"
+    do jfld = 1, numfld
+      checksum_hex = discontiguous_fletcher16_hex(gspfld(jfld:jfld,:))
+      call append_checksum(noutdump, checksum_run, checksum_hex, "zspdiv", [jfld], "divergence")
+    enddo
   else
     call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspdiv)
   endif
@@ -1907,7 +2146,7 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
       call gath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
         &            kvset=ivset, pspec=zspsc3a(:,:,jfld))
       checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
-      write(noutdump, '(a," # ",a,"(",i0,")")') checksum_hex, "zspsc3a", jfld
+      call append_checksum(noutdump, checksum_run, checksum_hex, "zspsc3a", [jfld], "scalar-3d")
     else
       call gath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=zspsc3a(:,:,jfld))
     endif
@@ -1916,12 +2155,13 @@ subroutine dump_checksums_psp_3a_2(filename, noutdump,  &
   if (myproc == 1) then
     call gath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc2, pspec=zspsc2)
     checksum_hex = discontiguous_fletcher16_hex(gspfld(1:1,:))
-    write(noutdump, '(a," # ",a)') checksum_hex, "zspsc2"
+    call append_checksum(noutdump, checksum_run, checksum_hex, "zspsc2", description="scalar-2d")
   else
     call gath_spec(kfgathg=1, kto=[1], kvset=ivsetsc2, pspec=zspsc2)
   endif
 
   if (myproc == 1) then
+    call flush_checksum_run(noutdump, checksum_run)
     write(nout,*) "close ", noutdump
     close(noutdump)
     if (allocated(gspfld)) deallocate(gspfld)

--- a/src/programs/ectrans-lam-benchmark.F90
+++ b/src/programs/ectrans-lam-benchmark.F90
@@ -73,7 +73,7 @@ integer(kind=jpim) :: nlat    = 128   ! Meridional dimension
 integer(kind=jpim) :: nsmax   = 0   ! Spectral meridional truncation
 integer(kind=jpim) :: nmsmax  = 0   ! Spectral zonal truncation
 integer(kind=jpim) :: iters   = 10  ! Number of iterations for transform test
-integer(kind=jpim) :: iters_warmup = 0 ! Number of warm up steps (for which timing statistics should be ignored)
+integer(kind=jpim) :: iters_warmup = 3 ! Number of warm up steps (for which timing statistics should be ignored)
 integer(kind=jpim) :: iters_checksums = -1 ! Number of iterations for which checksum output is written
 integer(kind=jpim) :: nfld    = 1   ! Number of scalar fields
 integer(kind=jpim) :: nlev    = 1   ! Number of vertical levels
@@ -568,19 +568,9 @@ endif
 
 if (iters <= 0) call abor1('transform_test:iters <= 0')
 
-allocate(ztstep(iters))
-allocate(ztstep1(iters))
-allocate(ztstep2(iters))
-
-ztstepavg  = 0._jprd
-ztstepmax  = 0._jprd
-ztstepmin  = 9999999999999999._jprd
-ztstepavg1 = 0._jprd
-ztstepmax1 = 0._jprd
-ztstepmin1 = 9999999999999999._jprd
-ztstepavg2 = 0._jprd
-ztstepmax2 = 0._jprd
-ztstepmin2 = 9999999999999999._jprd
+allocate(ztstep(iters+iters_warmup))
+allocate(ztstep1(iters+iters_warmup))
+allocate(ztstep2(iters+iters_warmup))
 
 !=================================================================================================
 ! Dump the values to disk, for debugging only
@@ -601,13 +591,18 @@ endif
 write(nout,'(a)') '======= Start of spectral transforms  ======='
 write(nout,'(" ")')
 
-ztloop = timef() / 1000.0_jprd
+write(nout,'(a,i0,a,i0,a)') 'Running for ', iters, ' iterations with ', iters_warmup, &
+  & ' extra warm-up iterations'
+write(nout,'(" ")')
 
 !===================================================================================================
 ! Do spectral transform loop
 !===================================================================================================
 
-do jstep = 1, iters
+do jstep = 1, iters+iters_warmup
+  if (jstep == iters_warmup + 1) then
+    ztloop = timef() / 1000.0_jprd
+  endif
 
   if( lstats ) call gstats(3,0)
   ztstep(jstep) = timef() / 1000.0_jprd
@@ -757,24 +752,22 @@ do jstep = 1, iters
 
   ztstep(jstep) = (timef() / 1000.0_jprd - ztstep(jstep))
 
-  ztstepavg = ztstepavg + ztstep(jstep)
-  ztstepmin = min(ztstep(jstep), ztstepmin)
-  ztstepmax = max(ztstep(jstep), ztstepmax)
-
-  ztstepavg1 = ztstepavg1 + ztstep1(jstep)
-  ztstepmin1 = min(ztstep1(jstep), ztstepmin1)
-  ztstepmax1 = max(ztstep1(jstep), ztstepmax1)
-
-  ztstepavg2 = ztstepavg2 + ztstep2(jstep)
-  ztstepmin2 = min(ztstep2(jstep), ztstepmin2)
-  ztstepmax2 = max(ztstep2(jstep), ztstepmax2)
-
   !=================================================================================================
   ! Print norms
   !=================================================================================================
 
   if (lprint_norms) then
     if( lstats ) call gstats(6,0)
+  ztstepavg = sum(ztstep(iters_warmup+1:))
+  ztstepmin = minval(ztstep(iters_warmup+1:))
+  ztstepmax = maxval(ztstep(iters_warmup+1:))
+  ztstepavg1 = sum(ztstep1(iters_warmup+1:))
+  ztstepmin1 = minval(ztstep1(iters_warmup+1:))
+  ztstepmax1 = maxval(ztstep1(iters_warmup+1:))
+  ztstepavg2 = sum(ztstep2(iters_warmup+1:))
+  ztstepmin2 = minval(ztstep2(iters_warmup+1:))
+  ztstepmax2 = maxval(ztstep2(iters_warmup+1:))
+
 
     call especnorm(pspec=zspsc2(1:1,:),         pnorm=znormsp,  kvset=ivsetsc(1:1))
     if ( lvordiv ) then
@@ -959,20 +952,20 @@ ztstepavg = (ztstepavg/real(nproc,jprb))/real(iters,jprd)
 ztloop = ztloop/real(nproc,jprd)
 ztstep(:) = ztstep(:)/real(nproc,jprd)
 
-call sort(ztstep,iters)
-ztstepmed = ztstep(iters/2)
+call sort(ztstep(iters_warmup+1:), iters)
+ztstepmed = ztstep(iters_warmup + iters/2)
 
 ztstepavg1 = (ztstepavg1/real(nproc,jprb))/real(iters,jprd)
 ztstep1(:) = ztstep1(:)/real(nproc,jprd)
 
-call sort(ztstep1, iters)
-ztstepmed1 = ztstep1(iters/2)
+call sort(ztstep1(iters_warmup+1:), iters)
+ztstepmed1 = ztstep1(iters_warmup + iters/2)
 
 ztstepavg2 = (ztstepavg2/real(nproc,jprb))/real(iters,jprd)
 ztstep2(:) = ztstep2(:)/real(nproc,jprd)
 
-call sort(ztstep2,iters)
-ztstepmed2 = ztstep2(iters/2)
+call sort(ztstep2(iters_warmup+1:), iters)
+ztstepmed2 = ztstep2(iters_warmup + iters/2)
 
 
 write(nout,'(a)') '======= Start of time step stats ======='
@@ -1315,7 +1308,7 @@ subroutine print_help(unit)
   write(nout, "(a)") "    -n, --niter NITER   Run for this many inverse/direct transform&
     & iterations (default = 10)"
   write(nout, "(a)") "    --niter-warmup      Number of warm up iterations,&
-    & for which timing statistics should be ignored (default = 0, and currently not implemented!)"
+    & for which timing statistics should be ignored (default = 3)"
   write(nout, "(a)") "    --niter-checksums  Number of iterations for which checksum output is&
     & written, counting warmup iterations too (default = --niter-warmup > 0 ? --niter-warmup : --niter)"
   write(nout, "(a)") "    -f, --nfld NFLD     Number of scalar fields (default = 1)"

--- a/src/programs/ectrans-lam-benchmark.F90
+++ b/src/programs/ectrans-lam-benchmark.F90
@@ -137,7 +137,6 @@ logical :: lmeminfo = .false. ! Show information from FIAT routine ec_meminfo at
 integer(kind=jpim) :: nstats_mem = 0
 integer(kind=jpim) :: ntrace_stats = 0
 integer(kind=jpim) :: nprnt_stats = 1
-character(len=1024) :: checksums_filename
 
 ! The multiplier of the machine epsilon used as a tolerance for correctness checking
 ! ncheck = 0 (the default) means that correctness checking is disabled
@@ -640,8 +639,7 @@ do jstep = 1, iters
     ! Remove trash at end of last block
     iend = ngptot - nproma * (ngpblks - 1)
     zgp2 (iend+1:, :, ngpblks) = 0
-    write (checksums_filename,'(A)') trim(cchecksums_path)
-    call dump_checksums(filename = checksums_filename, noutdump = noutdump,                 &
+    call dump_checksums(filename = cchecksums_path, noutdump = noutdump,                 &
                       & jstep = jstep, myproc = myproc, nproma = nproma, ngptotg = ngptotg, &
                       & ivset = ivset, ivsetsc = ivsetsc,                                   &
                       & nspec2g = nspec2g, zgpuv = zgpuv, zgp3a = zgpuv, zgp2 = zgp2)
@@ -727,8 +725,7 @@ do jstep = 1, iters
   endif
 
   if (ldump_checksums) then
-    write (checksums_filename,'(A)') trim(cchecksums_path)
-    call dump_checksums(filename = checksums_filename, noutdump = noutdump,                 &
+    call dump_checksums(filename = cchecksums_path, noutdump = noutdump,                 &
                       & jstep = jstep, myproc = myproc, nproma = nproma, ngptotg = ngptotg, &
                       & ivset = ivset, ivsetsc = ivsetsc,                                   &
                       & nspec2g = nspec2g, sp3d = sp3d, zspc2 = zspsc2, append_checksums=.true.)

--- a/src/programs/ectrans-lam-benchmark.F90
+++ b/src/programs/ectrans-lam-benchmark.F90
@@ -137,7 +137,7 @@ logical :: lmeminfo = .false. ! Show information from FIAT routine ec_meminfo at
 integer(kind=jpim) :: nstats_mem = 0
 integer(kind=jpim) :: ntrace_stats = 0
 integer(kind=jpim) :: nprnt_stats = 1
-character(len=256) :: checksums_filename
+character(len=1024) :: checksums_filename
 
 ! The multiplier of the machine epsilon used as a tolerance for correctness checking
 ! ncheck = 0 (the default) means that correctness checking is disabled
@@ -203,7 +203,7 @@ logical :: luse_mpi = .true.
 logical :: lalloperm = .true.
 integer, external :: ec_mpirank
 
-character(len=128)  :: cchecksums_path = ''
+character(len=1024) :: cchecksums_path = ''
 integer(kind=jpim)  :: ierr
 real(kind=jprb) :: zexwn, zeywn
 
@@ -640,7 +640,7 @@ do jstep = 1, iters
     ! Remove trash at end of last block
     iend = ngptot - nproma * (ngpblks - 1)
     zgp2 (iend+1:, :, ngpblks) = 0
-    write (checksums_filename,'(A)') trim(cchecksums_path)//'_inv_trans.checksums'
+    write (checksums_filename,'(A)') trim(cchecksums_path)
     call dump_checksums(filename = checksums_filename, noutdump = noutdump,                 &
                       & jstep = jstep, myproc = myproc, nproma = nproma, ngptotg = ngptotg, &
                       & ivset = ivset, ivsetsc = ivsetsc,                                   &
@@ -727,11 +727,11 @@ do jstep = 1, iters
   endif
 
   if (ldump_checksums) then
-    write (checksums_filename,'(A)') trim(cchecksums_path)//'_dir_trans.checksums'
+    write (checksums_filename,'(A)') trim(cchecksums_path)
     call dump_checksums(filename = checksums_filename, noutdump = noutdump,                 &
                       & jstep = jstep, myproc = myproc, nproma = nproma, ngptotg = ngptotg, &
                       & ivset = ivset, ivsetsc = ivsetsc,                                   &
-                      & nspec2g = nspec2g, sp3d = sp3d, zspc2 = zspsc2)
+                      & nspec2g = nspec2g, sp3d = sp3d, zspc2 = zspsc2, append_checksums=.true.)
   endif
 
   !=================================================================================================
@@ -1079,7 +1079,7 @@ end function
 
 function get_str_value(cname, iarg) result(value)
 
-  character(len=128) :: value
+  character(len=1024) :: value
   character(len=*), intent(in) :: cname
   integer, intent(inout) :: iarg
 
@@ -1138,7 +1138,7 @@ subroutine get_command_line_arguments(nlon, nlat, nsmax, nmsmax, &
   integer, intent(inout) :: nprtrw          ! Size of W set (spectral decomposition)
   integer, intent(inout) :: ncheck          ! The multiplier of the machine epsilon used as a
                                             ! tolerance for correctness checking
-  character(len=128), intent(inout) :: cchecksums_path ! path to export checksum files
+  character(len=1024), intent(inout) :: cchecksums_path ! path to export checksum files
   logical, intent(inout) :: lalloperm                  ! keep FOUBUF & FOUBUF_IN allocated
   character(len=128) :: carg          ! Storage variable for command line arguments
   integer            :: iarg          ! Argument index
@@ -1563,10 +1563,29 @@ end subroutine dump_spectral_field
 
 !===================================================================================================
 
+function discontiguous_fletcher16_hex(field) result(checksum_hex)
+
+  use ec_checksum_mod, only : fletcher16_hex
+
+  real(kind=jprb), intent(in) :: field(:,:)
+  character(len=4) :: checksum_hex
+  real(kind=jprb), allocatable :: contiguous_field(:,:)
+
+  ! Although fletcher16_hex has the CONTIGUOUS attribute, it was not respected by the NVHPC 26.3 compiler.
+  ! Make an explicit contiguous copy before passing a potentially discontiguous array section.
+  allocate(contiguous_field(size(field,1), size(field,2)))
+  contiguous_field(:,:) = field(:,:)
+  checksum_hex = fletcher16_hex(contiguous_field)
+
+end function discontiguous_fletcher16_hex
+
+!===================================================================================================
+
 subroutine dump_checksums(filename, noutdump, &
   & jstep, myproc, nproma, ngptotg, nspec2g,  &
   & ivset, ivsetsc,                           &
-  & zgpuv, zgp3a, zgp2, sp3d, zspc2)
+  & zgpuv, zgp3a, zgp2, sp3d, zspc2, append_checksums)
+  use ec_checksum_mod, only : fletcher16_hex
 
   character(len=*),   intent(in) :: filename   ! filename
   integer(kind=jpim), intent(in) :: noutdump   ! unit number for output file
@@ -1583,24 +1602,34 @@ subroutine dump_checksums(filename, noutdump, &
   real(kind=jprb), intent(in), optional :: zgp2  (:,:,:)
   real(kind=jprb), intent(in), optional :: sp3d  (:,:,:)
   real(kind=jprb), intent(in), optional :: zspc2 (:,:)
+  logical, intent(in), optional :: append_checksums
 
-  integer(kind=jpib) :: icrc
   integer(kind=jpim) :: jlev, jfld, numfld
   real(kind=jprb), allocatable :: gfld(:,:)
   real(kind=jprb), allocatable :: gspfld(:,:)
   logical :: exist = .false.
+  logical :: append
+  integer(kind=jpim), save :: last_header_jstep = -1
+  character(len=4) :: checksum_hex
 
   if (myproc == 1) then
-    if (jstep>1)  inquire(file = filename, exist = exist)
+    append = .false.
+    if (present(append_checksums)) append = append_checksums
+    if (jstep > 1) append = .true.
+    if (append) inquire(file = filename, exist = exist)
       if (exist) then
         open(noutdump, file = filename, status="old", position="append", action="write")
       else
         open(noutdump, file = filename, action="write")
+        last_header_jstep = -1
     endif
 
-    write(noutdump,*) "===================="
-    write(noutdump,*) "iteration", jstep
-    write(noutdump,*) "===================="
+    if (jstep /= last_header_jstep) then
+      write(noutdump,'(a)')     "# --------------------------------------------"
+      write(noutdump,'(a, i0)') "# Iteration ", jstep
+      write(noutdump,'(a)')     "# --------------------------------------------"
+      last_header_jstep = jstep
+    endif
 
     if (present(zgpuv) .or. present(zgp3a) .or. present(zgp2))  allocate(gfld(ngptotg,1))
     if (present(sp3d) .or. present(zspc2))  allocate(gspfld(max(size(ivset), 1), nspec2g))
@@ -1608,38 +1637,35 @@ subroutine dump_checksums(filename, noutdump, &
   endif
 
   if (present(zgpuv)) then
-    icrc = 0
     do jfld = 1, size (zgpuv, 3)
       do jlev = 1, size (zgpuv, 2)
         call egath_grid(pgpg=gfld,kproma=nproma,kfgathg=1,kto=(/1/),kresol=1,pgp=zgpuv(:,jlev:jlev,jfld, :))
         if (myproc == 1) then
-          call crc64 (gfld (:, :), int (size (gfld (:, :)) * kind (gfld), 8), icrc)
-          write (noutdump, '(a," (",i0,", ",i0,") = ",z16.16)') "zgpuv", jlev, jfld, icrc
+          checksum_hex = fletcher16_hex(gfld(:,:))
+          write (noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgpuv", jlev, jfld
         endif
       enddo
     enddo
   endif
 
   if (present(zgp3a)) then
-    icrc = 0
     do jfld = 1, size (zgp3a, 3)
       do jlev = 1, size (zgp3a, 2)
         call egath_grid(pgpg=gfld,kproma=nproma,kfgathg=1,kto=(/1/),kresol=1,pgp=zgp3a(:,jlev:jlev,jfld, :))
         if (myproc == 1) then
-          call crc64 (gfld (:, :), int (size (gfld (:, :)) * kind (gfld), 8), icrc)
-          write (noutdump, '(a," (",i0,", ",i0,") = ",z16.16)') "zgp3a", jlev, jfld, icrc
+          checksum_hex = fletcher16_hex(gfld(:,:))
+          write (noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgp3a", jlev, jfld
         endif
       enddo
     enddo
   endif
 
   if (present(zgp2)) then
-    icrc = 0
     do jfld = 1, size (zgp2, 2)
       call egath_grid(pgpg=gfld,kproma=nproma,kfgathg=1,kto=(/1/),kresol=1,pgp=zgp2(:,jfld:jfld,:))
       if (myproc == 1) then
-        call crc64 (gfld (:, :), int (size (gfld (:, :)) * kind (gfld), 8), icrc)
-        write (noutdump, '(a," (",i0,") = ",z16.16)') "zgp2", jfld, icrc
+        checksum_hex = fletcher16_hex(gfld(:,:))
+        write (noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp2", jfld
       endif
     enddo
   endif
@@ -1649,9 +1675,8 @@ subroutine dump_checksums(filename, noutdump, &
       if (myproc == 1) then
         call egath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
           &             kvset=ivset, pspec=sp3d(:,:,jfld))
-        icrc = 0
-        call crc64(gspfld(1:numfld,:), int(size(gspfld(1:numfld,:)) * kind(gspfld), 8), icrc)
-        write(noutdump, '(a,"(",i0,") = ",z16.16)') "sp3d", jfld, icrc
+        checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
+        write(noutdump, '(a," # ",a,"(",i0,")")') checksum_hex, "sp3d", jfld
       else
         call egath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=sp3d(:,:,jfld))
       endif
@@ -1661,9 +1686,8 @@ subroutine dump_checksums(filename, noutdump, &
   if (present(zspc2)) then
     if (myproc == 1) then
       call egath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc, pspec=zspc2)
-      icrc = 0
-      call crc64(gspfld(1,:), int(size(gspfld(1,:)) * kind(gspfld), 8), icrc)
-      write (noutdump, '(a," = ",z16.16)') "zspc2", icrc
+      checksum_hex = discontiguous_fletcher16_hex(gspfld(1:1,:))
+      write (noutdump, '(a," # ",a)') checksum_hex, "zspc2"
     else
       call egath_spec(kfgathg=1, kto=[1], kvset=ivsetsc, pspec=zspc2)
     endif

--- a/src/programs/ectrans-lam-benchmark.F90
+++ b/src/programs/ectrans-lam-benchmark.F90
@@ -642,7 +642,7 @@ do jstep = 1, iters
     call dump_checksums(filename = cchecksums_path, noutdump = noutdump,                 &
                       & jstep = jstep, myproc = myproc, nproma = nproma, ngptotg = ngptotg, &
                       & ivset = ivset, ivsetsc = ivsetsc,                                   &
-                      & nspec2g = nspec2g, zgpuv = zgpuv, zgp3a = zgpuv, zgp2 = zgp2)
+                      & nspec2g = nspec2g, zgpuv = zgpuv, zgp3a = zgp3a, zgp2 = zgp2)
   endif
 
   ztstep1(jstep) = (timef() / 1000.0_jprd - ztstep1(jstep))

--- a/src/programs/ectrans-lam-benchmark.F90
+++ b/src/programs/ectrans-lam-benchmark.F90
@@ -58,6 +58,15 @@ integer(kind=jpim), parameter :: nerr     = 0 ! Unit number for STDERR
 integer(kind=jpim), parameter :: nout     = 6 ! Unit number for STDOUT
 integer(kind=jpim), parameter :: noutdump = 7 ! Unit number for field output
 
+type checksum_run_type
+  character(len=4) :: checksum = ""
+  character(len=16) :: label = ""
+  integer(kind=jpim) :: first_indices(2) = 0
+  integer(kind=jpim) :: last_indices(2) = 0
+  integer(kind=jpim) :: num_indices = 0
+  integer(kind=jpim) :: count = 0
+end type checksum_run_type
+
 ! Default parameters
 integer(kind=jpim) :: nlon    = 128   ! Zonal dimension
 integer(kind=jpim) :: nlat    = 128   ! Meridional dimension
@@ -1578,6 +1587,101 @@ end function discontiguous_fletcher16_hex
 
 !===================================================================================================
 
+function format_checksum_location(first_indices, last_indices, num_indices) result(location)
+
+  integer(kind=jpim), intent(in) :: first_indices(2)
+  integer(kind=jpim), intent(in) :: last_indices(2)
+  integer(kind=jpim), intent(in) :: num_indices
+  character(len=32) :: location
+
+  location = ""
+  select case (num_indices)
+    case (0)
+    case (1)
+      if (first_indices(1) == last_indices(1)) then
+        write(location, '("(",i0,")")') first_indices(1)
+      else
+        write(location, '("(",i0,"-",i0,")")') first_indices(1), last_indices(1)
+      endif
+    case (2)
+      if (first_indices(1) == last_indices(1) .and. first_indices(2) == last_indices(2)) then
+        write(location, '("(",i0,", ",i0,")")') first_indices(1), first_indices(2)
+      else if (first_indices(1) == last_indices(1)) then
+        write(location, '("(",i0,", ",i0,"-",i0,")")') &
+          & first_indices(1), first_indices(2), last_indices(2)
+      else if (first_indices(2) == last_indices(2)) then
+        write(location, '("(",i0,"-",i0,", ",i0,")")') &
+          & first_indices(1), last_indices(1), first_indices(2)
+      else
+        write(location, '("(",i0,"-",i0,", ",i0,"-",i0,")")') &
+          & first_indices(1), last_indices(1), first_indices(2), last_indices(2)
+      endif
+    case default
+      call abor1('format_checksum_location supports at most two indices')
+  end select
+
+end function format_checksum_location
+
+!===================================================================================================
+
+subroutine flush_checksum_run(noutdump, run)
+
+  integer(kind=jpim), intent(in) :: noutdump
+  type(checksum_run_type), intent(inout) :: run
+  character(len=32) :: location
+
+  if (run%count == 0) return
+
+  location = format_checksum_location(run%first_indices, run%last_indices, run%num_indices)
+  if (location == "") then
+    write(noutdump, '(a,1x,i4," # ",a)') run%checksum, run%count, trim(run%label)
+  else
+    write(noutdump, '(a,1x,i4," # ",a,1x,a)') &
+      & run%checksum, run%count, trim(run%label), trim(location)
+  endif
+
+  run%checksum = ""
+  run%label = ""
+  run%first_indices = 0
+  run%last_indices = 0
+  run%num_indices = 0
+  run%count = 0
+
+end subroutine flush_checksum_run
+
+!===================================================================================================
+
+subroutine append_checksum(noutdump, run, checksum, label, indices)
+
+  integer(kind=jpim), intent(in) :: noutdump
+  type(checksum_run_type), intent(inout) :: run
+  character(len=*), intent(in) :: checksum
+  character(len=*), intent(in) :: label
+  integer(kind=jpim), intent(in), optional :: indices(:)
+
+  if (present(indices)) then
+    if (size(indices) > 2) call abor1('append_checksum supports at most two indices')
+  endif
+
+  if (run%count > 0) then
+    if (checksum /= run%checksum .or. label /= trim(run%label)) call flush_checksum_run(noutdump, run)
+  endif
+
+  if (run%count == 0) then
+    run%checksum = checksum
+    run%label = label
+    if (present(indices)) then
+      run%first_indices(1:size(indices)) = indices
+      run%num_indices = size(indices)
+    endif
+  endif
+  if (present(indices)) run%last_indices(1:size(indices)) = indices
+  run%count = run%count + 1
+
+end subroutine append_checksum
+
+!===================================================================================================
+
 subroutine dump_checksums(filename, noutdump, &
   & jstep, myproc, nproma, ngptotg, nspec2g,  &
   & ivset, ivsetsc,                           &
@@ -1608,6 +1712,7 @@ subroutine dump_checksums(filename, noutdump, &
   logical :: append
   integer(kind=jpim), save :: last_header_jstep = -1
   character(len=4) :: checksum_hex
+  type(checksum_run_type) :: checksum_run
 
   if (myproc == 1) then
     append = .false.
@@ -1639,7 +1744,7 @@ subroutine dump_checksums(filename, noutdump, &
         call egath_grid(pgpg=gfld,kproma=nproma,kfgathg=1,kto=(/1/),kresol=1,pgp=zgpuv(:,jlev:jlev,jfld, :))
         if (myproc == 1) then
           checksum_hex = fletcher16_hex(gfld(:,:))
-          write (noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgpuv", jlev, jfld
+          call append_checksum(noutdump, checksum_run, checksum_hex, "zgpuv", [jlev, jfld])
         endif
       enddo
     enddo
@@ -1651,7 +1756,7 @@ subroutine dump_checksums(filename, noutdump, &
         call egath_grid(pgpg=gfld,kproma=nproma,kfgathg=1,kto=(/1/),kresol=1,pgp=zgp3a(:,jlev:jlev,jfld, :))
         if (myproc == 1) then
           checksum_hex = fletcher16_hex(gfld(:,:))
-          write (noutdump, '(a," # ",a," (",i0,", ",i0,")")') checksum_hex, "zgp3a", jlev, jfld
+          call append_checksum(noutdump, checksum_run, checksum_hex, "zgp3a", [jlev, jfld])
         endif
       enddo
     enddo
@@ -1662,7 +1767,7 @@ subroutine dump_checksums(filename, noutdump, &
       call egath_grid(pgpg=gfld,kproma=nproma,kfgathg=1,kto=(/1/),kresol=1,pgp=zgp2(:,jfld:jfld,:))
       if (myproc == 1) then
         checksum_hex = fletcher16_hex(gfld(:,:))
-        write (noutdump, '(a," # ",a," (",i0,")")') checksum_hex, "zgp2", jfld
+        call append_checksum(noutdump, checksum_run, checksum_hex, "zgp2", [jfld])
       endif
     enddo
   endif
@@ -1673,7 +1778,7 @@ subroutine dump_checksums(filename, noutdump, &
         call egath_spec(pspecg=gspfld(1:numfld,:), kfgathg=numfld, kto=[(1, i = 1, numfld)], &
           &             kvset=ivset, pspec=sp3d(:,:,jfld))
         checksum_hex = discontiguous_fletcher16_hex(gspfld(1:numfld,:))
-        write(noutdump, '(a," # ",a,"(",i0,")")') checksum_hex, "sp3d", jfld
+        call append_checksum(noutdump, checksum_run, checksum_hex, "sp3d", [jfld])
       else
         call egath_spec(kfgathg=numfld, kto=[(1, i = 1, numfld)], kvset=ivset, pspec=sp3d(:,:,jfld))
       endif
@@ -1684,13 +1789,14 @@ subroutine dump_checksums(filename, noutdump, &
     if (myproc == 1) then
       call egath_spec(pspecg=gspfld(1:1,:), kfgathg=1, kto=[1], kvset=ivsetsc, pspec=zspc2)
       checksum_hex = discontiguous_fletcher16_hex(gspfld(1:1,:))
-      write (noutdump, '(a," # ",a)') checksum_hex, "zspc2"
+      call append_checksum(noutdump, checksum_run, checksum_hex, "zspc2")
     else
       call egath_spec(kfgathg=1, kto=[1], kvset=ivsetsc, pspec=zspc2)
     endif
   endif
 
   if (myproc == 1) then
+    call flush_checksum_run(noutdump, checksum_run)
     close(noutdump)
     if (allocated(gfld))   deallocate(gfld)
     if (allocated(gspfld)) deallocate(gspfld)

--- a/src/programs/ectrans-lam-benchmark.F90
+++ b/src/programs/ectrans-lam-benchmark.F90
@@ -73,6 +73,8 @@ integer(kind=jpim) :: nlat    = 128   ! Meridional dimension
 integer(kind=jpim) :: nsmax   = 0   ! Spectral meridional truncation
 integer(kind=jpim) :: nmsmax  = 0   ! Spectral zonal truncation
 integer(kind=jpim) :: iters   = 10  ! Number of iterations for transform test
+integer(kind=jpim) :: iters_warmup = 0 ! Number of warm up steps (for which timing statistics should be ignored)
+integer(kind=jpim) :: iters_checksums = -1 ! Number of iterations for which checksum output is written
 integer(kind=jpim) :: nfld    = 1   ! Number of scalar fields
 integer(kind=jpim) :: nlev    = 1   ! Number of vertical levels
 
@@ -235,9 +237,18 @@ real(kind=jprb) :: zexwn, zeywn
 luse_mpi = detect_mpirun()
 
 ! Setup
-call get_command_line_arguments(nlon, nlat, nsmax, nmsmax, iters, nfld, nlev, lvordiv, lscders, luvders, &
-                              & nproma, verbosity, ldump_values, ldump_checksums, lprint_norms, lmeminfo, &
-                              & nprgpns, nprgpew, nprtrv, nprtrw, ncheck,cchecksums_path, lalloperm)
+call get_command_line_arguments(nlon, nlat, nsmax, nmsmax, iters, iters_warmup, iters_checksums, nfld, nlev, &
+                              & lvordiv, lscders, luvders, nproma, verbosity, ldump_values, ldump_checksums, &
+                              & lprint_norms, lmeminfo, nprgpns, nprgpew, nprtrv, nprtrw, ncheck, &
+                              & cchecksums_path, lalloperm)
+if (iters_checksums < 0) then
+  if (iters_warmup > 0) then
+    iters_checksums = iters_warmup
+  else 
+    iters_checksums = iters
+  endif
+endif
+
 ! derived defaults
 if ( nsmax == 0 ) nsmax = nlat/2-1
 if ( nmsmax == 0 ) nmsmax = nlon/2-1
@@ -644,7 +655,7 @@ do jstep = 1, iters
 
   if( lstats ) call gstats(4,1)
 
-  if (ldump_checksums) then
+  if (ldump_checksums .and. jstep <= iters_checksums) then
     ! Remove trash at end of last block
     iend = ngptot - nproma * (ngpblks - 1)
     zgp2 (iend+1:, :, ngpblks) = 0
@@ -733,7 +744,7 @@ do jstep = 1, iters
     endif
   endif
 
-  if (ldump_checksums) then
+  if (ldump_checksums .and. jstep <= iters_checksums) then
     call dump_checksums(filename = cchecksums_path, noutdump = noutdump,                 &
                       & jstep = jstep, myproc = myproc, nproma = nproma, ngptotg = ngptotg, &
                       & ivset = ivset, ivsetsc = ivsetsc,                                   &
@@ -1116,7 +1127,7 @@ end subroutine
 !===================================================================================================
 
 subroutine get_command_line_arguments(nlon, nlat, nsmax, nmsmax, &
-  &                                   iters, nfld, nlev, lvordiv, lscders, luvders, &
+  &                                   iters, iters_warmup, iters_checksums, nfld, nlev, lvordiv, lscders, luvders, &
   &                                   nproma, verbosity, ldump_values, ldump_checksums, lprint_norms, &
   &                                   lmeminfo, nprgpns, nprgpew, nprtrv, nprtrw, ncheck,cchecksums_path, &
   &                                   lalloperm)
@@ -1126,6 +1137,8 @@ subroutine get_command_line_arguments(nlon, nlat, nsmax, nmsmax, &
   integer, intent(inout) :: nsmax           ! Meridional truncation
   integer, intent(inout) :: nmsmax          ! Zonal trunciation
   integer, intent(inout) :: iters           ! Number of iterations for transform test
+  integer, intent(inout) :: iters_warmup    ! Number of warm up iterations
+  integer, intent(inout) :: iters_checksums ! Number of iterations for which checksum output is written
   integer, intent(inout) :: nfld            ! Number of scalar fields
   integer, intent(inout) :: nlev            ! Number of vertical levels
   logical, intent(inout) :: lvordiv         ! Also transform vorticity/divergence
@@ -1170,6 +1183,16 @@ subroutine get_command_line_arguments(nlon, nlat, nsmax, nmsmax, &
         iters = get_int_value('-n', iarg)
         if (iters < 1) then
           call parsing_failed("Invalid argument for -n: must be > 0")
+        end if
+      case('--niter-warmup')
+        iters_warmup = get_int_value('--niter-warmup', iarg)
+        if (iters_warmup < 0) then
+          call parsing_failed("Invalid argument for --niter-warmup: must be >= 0")
+        end if
+      case('--niter-checksums')
+        iters_checksums = get_int_value('--niter-checksums', iarg)
+        if (iters_checksums < 0) then
+          call parsing_failed("Invalid argument for --niter-checksums: must be >= 0")
         end if
       ! Parse spectral truncation argument
       case('--nlon'); nlon = get_int_value('--nlon', iarg)
@@ -1291,6 +1314,10 @@ subroutine print_help(unit)
   write(nout, "(a)") "    --nmsmax NMSMAX     Spectral truncation in zonal direction (default = NLON/2-1)"
   write(nout, "(a)") "    -n, --niter NITER   Run for this many inverse/direct transform&
     & iterations (default = 10)"
+  write(nout, "(a)") "    --niter-warmup      Number of warm up iterations,&
+    & for which timing statistics should be ignored (default = 0, and currently not implemented!)"
+  write(nout, "(a)") "    --niter-checksums  Number of iterations for which checksum output is&
+    & written, counting warmup iterations too (default = --niter-warmup > 0 ? --niter-warmup : --niter)"
   write(nout, "(a)") "    -f, --nfld NFLD     Number of scalar fields (default = 1)"
   write(nout, "(a)") "    -l, --nlev NLEV     Number of vertical levels (default = 1)"
   write(nout, "(a)") "    --vordiv            Also transform vorticity-divergence to wind"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,7 +154,7 @@ foreach( benchmark ${benchmarks} )
 
       # Base arguments -> 2 iterations, memory consumption/pinning information, spectral norms, and
       # verbose output
-      set( base_args --niter 2 --meminfo --norms -v )
+      set( base_args --niter 2 --niter-checksums 2 --meminfo --norms -v )
 
       foreach( callmode 1 2 )
         set (base_title "${benchmark}_T${t}_${grid}_mpi${mpi}_omp${omp}_callmode${callmode}")
@@ -268,7 +268,7 @@ foreach( benchmark ${benchmarks} )
 
       # Base arguments -> 2 iterations, memory consumption/pinning information, spectral norms, and
       # verbose output
-      set( base_args --niter 2 --meminfo --norms -v --field-api)
+      set( base_args --niter 2 --niter-checksums 2 --meminfo --norms -v --field-api)
       foreach( callmode 1 2 )
       set (base_title "${benchmark}_T${t}_${grid}_mpi${mpi}_omp${omp}_callmode${callmode}_field_api")
 
@@ -359,7 +359,7 @@ if( HAVE_ETRANS )
 
       # Base arguments -> nlat x nlon, 2 iterations, memory consumption/pinning information,
       # spectral norms, and verbose output
-      set( base_args --nlon ${nlon} --nlat ${nlat} --niter 2 --meminfo --norms -v )
+      set( base_args --nlon ${nlon} --nlat ${nlat} --niter 2 --niter-checksums 2 --meminfo --norms -v )
 
       foreach( mpi ${ntasks} )
         foreach( omp ${nthreads} )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -161,7 +161,7 @@ foreach( benchmark ${benchmarks} )
         # Check it works with 0 3D scalar fields
         ecbuild_add_test( TARGET ${base_title}_nfld0
             COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld0 ${base_args}
+            ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld0.checksums ${base_args}
             MPI ${mpi}
             OMP ${omp}
         )
@@ -170,7 +170,7 @@ foreach( benchmark ${benchmarks} )
         # Check it works with 10 3D scalar fields and 20 levels
         ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20
             COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20 ${base_args}
+            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20.checksums ${base_args}
             MPI ${mpi}
             OMP ${omp}
         )
@@ -179,7 +179,7 @@ foreach( benchmark ${benchmarks} )
         # Check it works with 10 3D scalar fields, 20 levels, and derivatives
         ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_derivatives
             COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --scders --uvders --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_derivatives ${base_args}
+            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --scders --uvders --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_derivatives.checksums ${base_args}
             MPI ${mpi}
             OMP ${omp}
         )
@@ -188,7 +188,7 @@ foreach( benchmark ${benchmarks} )
         # Check it works with 10 3D scalar fields, 20 levels, and vordiv in grid point space
         ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_vordiv
             COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --vordiv --check 100  --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_vordiv ${base_args}
+            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --vordiv --check 100  --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_vordiv.checksums ${base_args}
             MPI ${mpi}
             OMP ${omp}
         )
@@ -197,7 +197,7 @@ foreach( benchmark ${benchmarks} )
         # Check it works with 10 3D scalar fields, 20 levels, and NPROMA=16
         ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_nproma16
             COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --nproma 16 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_nproma16 ${base_args}
+            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --nproma 16 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_nproma16.checksums ${base_args}
             MPI ${mpi}
             OMP ${omp}
         )
@@ -207,7 +207,7 @@ foreach( benchmark ${benchmarks} )
         if( ${benchmark} MATCHES "cpu" )
           ecbuild_add_test( TARGET ${base_title}_lalloperm_f
               COMMAND ${benchmark}
-              ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --check 100 --callmode ${callmode} --deallocate-foubuf-temps --dump-checksums ${base_title}_lalloperm_f ${base_args}
+              ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --check 100 --callmode ${callmode} --deallocate-foubuf-temps --dump-checksums ${base_title}_lalloperm_f.checksums ${base_args}
               MPI ${mpi}
               OMP ${omp}
           )
@@ -218,7 +218,7 @@ foreach( benchmark ${benchmarks} )
         if( ${benchmark} MATCHES "cpu" AND ${callmode} MATCHES "1" )
           ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_npromatr20
               COMMAND ${benchmark}
-              ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --npromatr 20 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_npromatr20 ${base_args}
+              ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --npromatr 20 --check 100 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_npromatr20.checksums ${base_args}
               MPI ${mpi}
               OMP ${omp}
           )
@@ -230,7 +230,7 @@ foreach( benchmark ${benchmarks} )
           # TODO: Find out why the FLT gives so much higher errors
           ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_flt
               COMMAND ${benchmark}
-              ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --flt --check 1000000 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_flt ${base_args}
+              ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --flt --check 1000000 --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_flt.checksums ${base_args}
               MPI ${mpi}
               OMP ${omp}
           )
@@ -276,7 +276,7 @@ foreach( benchmark ${benchmarks} )
       # Check it works with 0 3D scalar fields
       ecbuild_add_test( TARGET ${base_title}_nfld0
           COMMAND ${benchmark}
-          ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld0
+          ARGS --truncation ${t} --grid ${grid} --nfld 0 --check 100 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld0.checksums
           MPI ${mpi}
           OMP ${omp}
       )
@@ -286,7 +286,7 @@ foreach( benchmark ${benchmarks} )
       # Check it works with 10 3D scalar fields and 20 levels
       ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20
           COMMAND ${benchmark}
-          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --check 100 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld10_nlev20
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --check 100 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld10_nlev20.checksums
           MPI ${mpi}
           OMP ${omp}
       )
@@ -296,7 +296,7 @@ foreach( benchmark ${benchmarks} )
       # Check it works with 10 3D scalar fields, 20 levels, and scalar derivatives
       ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_derivatives
           COMMAND ${benchmark}
-          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --scders --check 100 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld10_nlev20_scders
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --scders --check 100 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld10_nlev20_scders.checksums
           MPI ${mpi}
           OMP ${omp}
       )
@@ -306,7 +306,7 @@ foreach( benchmark ${benchmarks} )
       # Check it works with 10 3D scalar fields, 20 levels, and wind transforms
       ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_vordiv
           COMMAND ${benchmark}
-          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --vordiv --check 100  ${base_args} --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_vordiv
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --vordiv --check 100  ${base_args} --callmode ${callmode} --dump-checksums ${base_title}_nfld10_nlev20_vordiv.checksums
           MPI ${mpi}
           OMP ${omp}
       )
@@ -316,7 +316,7 @@ foreach( benchmark ${benchmarks} )
       # Check it works with 10 3D scalar fields, 20 levels, and NPROMA=16
       ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_nproma16
           COMMAND ${benchmark}
-          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --nproma 16 --check 100 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld10_nlev20_nproma16
+          ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --nproma 16 --check 100 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld10_nlev20_nproma16.checksums
           MPI ${mpi}
           OMP ${omp}
       )
@@ -327,7 +327,7 @@ foreach( benchmark ${benchmarks} )
         # Check it works with 10 3D scalar fields, 20 levels, and the fast Legendre tranform (CPU only)
         ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_flt
             COMMAND ${benchmark}
-            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --flt --check 1000000 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld10_nlev20_flt
+            ARGS --truncation ${t} --grid ${grid} --nfld 10 --nlev 20 --flt --check 1000000 ${base_args} --callmode ${callmode}  --dump-checksums ${base_title}_nfld10_nlev20_flt.checksums
             MPI ${mpi}
             OMP ${omp}
         )
@@ -372,49 +372,49 @@ if( HAVE_ETRANS )
           set(base_title "ectrans_lam_test_benchmark_${prec}_${nlon}x${nlat}_mpi${mpi}_omp${omp}" )
 
           ecbuild_add_test( TARGET ${base_title}_nfld0
-              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 0 --dump-checksums ${base_title}_nfld0
+              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 0 --dump-checksums ${base_title}_nfld0.checksums
               MPI ${mpi}
               OMP ${omp}
           )
           ectrans_set_test_properties( ${base_title}_nfld0 )
 
           ecbuild_add_test( TARGET ${base_title}_nfld10
-              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --dump-checksums ${base_title}_nfld10
+              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --dump-checksums ${base_title}_nfld10.checksums
               MPI ${mpi}
               OMP ${omp}
           )
           ectrans_set_test_properties( ${base_title}_nfld10 )
 
           ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20
-              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --dump-checksums ${base_title}_nfld20
+              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --dump-checksums ${base_title}_nfld20.checksums
               MPI ${mpi}
               OMP ${omp}
           )
           ectrans_set_test_properties( ${base_title}_nfld10_nlev20 )
 
           ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_scders
-              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --scders --dump-checksums ${base_title}_nfld10_nlev20_scders
+              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --scders --dump-checksums ${base_title}_nfld10_nlev20_scders.checksums
               MPI ${mpi}
               OMP ${omp}
           )
           ectrans_set_test_properties(  ${base_title}_nfld10_nlev20_scders )
 
           ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_vordiv
-              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --vordiv --dump-checksums ${base_title}_nfld10_nlev20_vordiv
+              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --vordiv --dump-checksums ${base_title}_nfld10_nlev20_vordiv.checksums
               MPI ${mpi}
               OMP ${omp}
           )
           ectrans_set_test_properties( ${base_title}_nfld10_nlev20_vordiv )
 
           ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_vordiv_uvders
-              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --vordiv --uvders --dump-checksums ${base_title}_nfld10_nlev20_vordiv_uvders
+              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --vordiv --uvders --dump-checksums ${base_title}_nfld10_nlev20_vordiv_uvders.checksums
               MPI ${mpi}
               OMP ${omp}
           )
           ectrans_set_test_properties( ${base_title}_nfld10_nlev20_vordiv_uvders )
 
           ecbuild_add_test( TARGET ${base_title}_nfld10_nlev20_nproma16
-              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --nproma 16 --dump-checksums ${base_title}_nfld10_nlev20_nproma16
+              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --nproma 16 --dump-checksums ${base_title}_nfld10_nlev20_nproma16.checksums
               MPI ${mpi}
               OMP ${omp}
           )
@@ -422,7 +422,7 @@ if( HAVE_ETRANS )
 
           # Check it works with LALLOPERM=F (cpu only)
           ecbuild_add_test( TARGET ${base_title}_lalloperm_f
-              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --nproma 16 --deallocate-foubuf-temps --dump-checksums ${base_title}_lalloperm_f
+              COMMAND ectrans-lam-benchmark-cpu-${prec} ARGS ${base_args} --nfld 10 --nlev 20 --nproma 16 --deallocate-foubuf-temps --dump-checksums ${base_title}_lalloperm_f.checksums
               MPI ${mpi}
               OMP ${omp}
           )


### PR DESCRIPTION
### Description

This PR is in preparation for #434, and adapts the benchmark checksums generation. This is stacked on top of #440 which should be merged first. It took only relevant changes from #434 related to checksums.

This pull request makes several important updates to the `ectrans_benchmark` program, primarily focused on improving the consistency and clarity of checksum outputs, enhancing decomposition invariance, and modernizing the checksum logic. The changes ensure that benchmark results are stable across different MPI decompositions and that checksum files are easier to interpret and less dependent on execution details. Additionally, some technical and usability improvements are included.

### Checksum calculation and output modernization

* Replaced the legacy CRC64-based checksums with a new, more portable `fletcher16_hex` checksum, and updated all relevant subroutines (`dump_checksums_pgp`, `dump_checksums_pgp_uv_3a_2`, `dump_checksums_psp`, etc.) to use this new approach. This includes the addition of a helper function `discontiguous_fletcher16_hex` to ensure compatibility with compilers that do not respect the `CONTIGUOUS` attribute. 

* Updated the checksum file writing logic to include clearer headers, use append mode correctly across iterations, and consistently format output for easier parsing and comparison. The command-line help and variable names were also clarified to remove references to CRC.

* Only one checksum file instead of separate ones for dir_trans and inv_trans

* Checksum format is now as follows for e.g. `ectrans-benchmark-cpu-dp_T47_O48_mpi0_omp1_callmode1_nfld10_nlev20_derivatives.checksums`:
   ```
    # --------------------------------------------
    # Iteration 1
    # --------------------------------------------
    6a60   20 # zgp (1-20)               u
    ef60   20 # zgp (21-40)              v
    d1b0  200 # zgp (41-240)             scalar-3d
    d1b0    1 # zgp (241)                scalar-2d
    f9d3  200 # zgp (242-441)            scalar-3d-ns
    f9d3    1 # zgp (442)                scalar-2d-ns
    31cf   20 # zgp (443-462)            u-ew
    5aaf   20 # zgp (463-482)            v-ew
    edad  200 # zgp (483-682)            scalar-3d-ew
    edad    1 # zgp (683)                scalar-2d-ew
    d5af   20 # zspvor (1-20)            vorticity
    d629   20 # zspdiv (1-20)            divergence
    2d5f   10 # zspscalar (1-10)         scalar-3d
    675e    1 # zspscalar (11)           scalar-2d
    # --------------------------------------------
    # Iteration 2
    # --------------------------------------------
    3bc9   20 # zgp (1-20)               u
    4fc9   20 # zgp (21-40)              v
    1103  200 # zgp (41-240)             scalar-3d
    1103    1 # zgp (241)                scalar-2d
    0a97  200 # zgp (242-441)            scalar-3d-ns
    0a97    1 # zgp (442)                scalar-2d-ns
    d603   20 # zgp (443-462)            u-ew
    dbe2   20 # zgp (463-482)            v-ew
    35e5  200 # zgp (483-682)            scalar-3d-ew
    35e5    1 # zgp (683)                scalar-2d-ew
    c29f   20 # zspvor (1-20)            vorticity
    c12a   20 # zspdiv (1-20)            divergence
    f0af   10 # zspscalar (1-10)         scalar-3d
    4962    1 # zspscalar (11)           scalar-2d
   ```
   The output is reduced a lot, merging identical checksums into a single line. The second column shows how many duplications are merged. Especially for this case with 10 fields and 20 levels and since there are 5 iterations, this reduces the number of lines significantly. 

### Decomposition invariance and field ordering

* Fixed V-set assignment for 2D scalar fields in both callmode 1 and callmode 2 to ensure that the ordering and ownership of fields are stable and independent of MPI decomposition. This eliminates spurious checksum differences between serial and parallel runs.

* Also checksums should now be identical between callmode 1, callmode 2 and field_api version. Variations in files are only within comment section (see format above, where `#` starts a comment), so that a smarter diff will be able to compare various modes 

### Interface and argument improvements

* Increased the maximum length for checksum file paths and string command-line arguments from 128 to 1024 characters, improving robustness for long filenames or paths.

### Usability and documentation

* Updated help messages and variable names to reflect the new checksum logic, removing references to CRC and clarifying descriptions for users.

### Minor technical improvements

* Passed additional flags (`lscders`, `luvder`, `append_checksums`) to checksum dumping routines to support more flexible and correct output handling. This is to have different callmode output be compatible.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf-ifs/ectrans/blob/develop/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
