### PR TITLE
Add support for Fujitsu compiler

### DIFF
--- a/cmake/ectrans_compile_flags.cmake
+++ b/cmake/ectrans_compile_flags.cmake
@@ -6,7 +6,6 @@
 # granted to it by virtue of its status as an intergovernmental organisation
 # nor does it submit to any jurisdiction.
 
-
 # Base flags for all supported build types
 foreach( lang Fortran C CXX )
   ectrans_add_flags( "-g -O0"            BUILD DEBUG            LANG ${lang} )
@@ -15,12 +14,10 @@ foreach( lang Fortran C CXX )
   ectrans_add_flags( "-g -O2 -DNDEBUG"   BUILD BIT              LANG ${lang} )
 endforeach()
 
-
 # Flag to tell compiler that Fortran side has no program
 # Needed if linking a C executable against some Fortran objects with some compilers
 # Not needed for most
 set( NO_FORTRAN_MAIN_FLAG "" )
-
 
 if( CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" )
   # gfortran 10 has become stricter with argument matching
@@ -28,7 +25,6 @@ if( CMAKE_Fortran_COMPILER_ID STREQUAL "GNU" )
     ectrans_add_fortran_flags( "-fallow-argument-mismatch" )
   endif()
 endif()
-
 
 if( CMAKE_Fortran_COMPILER_ID STREQUAL "NVHPC" )
   ectrans_add_fortran_flags( "-Mlarge_arrays" )
@@ -56,7 +52,6 @@ if( CMAKE_Fortran_COMPILER_ID STREQUAL "Cray" )
   ectrans_add_fortran_flags( "-M7256" )
 endif()
 
-
 if( CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" OR CMAKE_Fortran_COMPILER_ID STREQUAL "Intel" )
   ectrans_add_fortran_flags( "-march=core-avx2 -no-fma" BUILD BIT )
   ectrans_add_fortran_flags( "-fp-model precise -fp-speculation=safe" )
@@ -66,7 +61,6 @@ if( CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM" OR CMAKE_Fortran_COMPILER_ID 
     ectrans_add_fortran_flags( "-fast-transcendentals" )
   endif()
 endif()
-
 
 if( CMAKE_Fortran_COMPILER_ID STREQUAL "XL" )
   ectrans_add_fortran_flags( "-qextname -qnobindcextname" )

--- a/cmake/ectrans_compile_flags.cmake
+++ b/cmake/ectrans_compile_flags.cmake
@@ -65,3 +65,7 @@ endif()
 if( CMAKE_Fortran_COMPILER_ID STREQUAL "XL" )
   ectrans_add_fortran_flags( "-qextname -qnobindcextname" )
 endif()
+
+if( CMAKE_Fortran_COMPILER_ID STREQUAL "Fujitsu" )
+  set( NO_FORTRAN_MAIN_FLAG "-mlcmain=main" )
+endif()


### PR DESCRIPTION
https://github.com/ecmwf-ifs/ectrans/commit/c63ba22bdd8af367183ddb51daa6331fc2f530d9 neglected to add the Fujitsu compiler's "don't add a `main` program" flag for Fujitsu, so here it is. This allows us to build the API test suite on Fugaku.