### PR TITLE
Fix multithreaded building with crayftn

### DIFF
--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -107,7 +107,6 @@ jobs:
               - ROCFFT_RTC_CACHE_PATH=$PWD/../../rocfft_kernel_cache.db
               - MPICH_GPU_SUPPORT_ENABLED=1
               - MPICH_SMP_SINGLE_COPY_MODE=NONE
-              - CMAKE_BUILD_PARALLEL_LEVEL=1
             ctest_options: -E compare_checksums # We don't bother with reproducibility checks on LUMI
             unsupported_dependency: ecmwf-ifs/field_api # We don't build Field API on LUMI for now
 

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -214,6 +214,7 @@ jobs:
             {% for name, options in dependencies.items() %}
               {% if name != unsupported_dependency %}
                 pushd {{name}}
+                configure_start=$(date +%s)
                 cmake -S . -B build \
                   {% for name in dependencies %}
                     {% if name != unsupported_dependency %}
@@ -222,13 +223,20 @@ jobs:
                     {% endif %}
                   {% endfor %}
                   {{ options['cmake_options']|join(' ') }}
+                configure_end=$(date +%s)
+                echo "{{name}} configure took $((configure_end - configure_start)) seconds"
+                build_install_start=$(date +%s)
                 cmake --build build
                 cmake --install build --prefix installation
+                build_install_end=$(date +%s)
+                echo "{{name}} configure took $((configure_end - configure_start)) seconds"
+                echo "{{name}} build and install took $((build_install_end - build_install_start)) seconds"
                 popd
               {% endif %}
             {% endfor %}
 
             # Build ecTrans
+            configure_start=$(date +%s)
             cmake -S $REPO -B build \
               {% for name in dependencies %}
                 {% if name != unsupported_dependency %}
@@ -237,8 +245,17 @@ jobs:
                 {% endif %}
               {% endfor %}
               {{ cmake_options|join(' ') }}
+            configure_end=$(date +%s)
+            echo "ecTrans configure took $((configure_end - configure_start)) seconds"
+            build_start=$(date +%s)
             cmake --build build
+            build_end=$(date +%s)
+            echo "ecTrans configure took $((configure_end - configure_start)) seconds"
+            echo "ecTrans build took $((build_end - build_start)) seconds"
 
+            test_start=$(date +%s)
             ctest --test-dir build --output-on-failure {{ ctest_options }}
+            test_end=$(date +%s)
+            echo "ecTrans tests took $((test_end - test_start)) seconds"
 
             cleanup

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -107,6 +107,7 @@ jobs:
               - ROCFFT_RTC_CACHE_PATH=$PWD/../../rocfft_kernel_cache.db
               - MPICH_GPU_SUPPORT_ENABLED=1
               - MPICH_SMP_SINGLE_COPY_MODE=NONE
+              - CMAKE_BUILD_PARALLEL_LEVEL=4
             ctest_options: -E compare_checksums # We don't bother with reproducibility checks on LUMI
             unsupported_dependency: ecmwf-ifs/field_api # We don't build Field API on LUMI for now
 

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -100,7 +100,6 @@ jobs:
               #SBATCH --time=01:10:00
               #SBATCH --nodes=1
               #SBATCH --ntasks-per-node=8
-              #SBATCH --cpus-per-task=4
               #SBATCH --gpus-per-task=1
               #SBATCH --partition=standard-g
               #SBATCH --account={0}
@@ -222,7 +221,7 @@ jobs:
                     {% endif %}
                   {% endfor %}
                   {{ options['cmake_options']|join(' ') }}
-                cmake --build build -j4
+                cmake --build build
                 cmake --install build --prefix installation
                 popd
               {% endif %}
@@ -237,7 +236,7 @@ jobs:
                 {% endif %}
               {% endfor %}
               {{ cmake_options|join(' ') }}
-            cmake --build build -j4
+            cmake --build build
 
             ctest --test-dir build --output-on-failure {{ ctest_options }}
 

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -107,7 +107,7 @@ jobs:
               - ROCFFT_RTC_CACHE_PATH=$PWD/../../rocfft_kernel_cache.db
               - MPICH_GPU_SUPPORT_ENABLED=1
               - MPICH_SMP_SINGLE_COPY_MODE=NONE
-              - CMAKE_BUILD_PARALLEL_LEVEL=4
+              - CMAKE_GENERATOR=Ninja
             ctest_options: -E compare_checksums # We don't bother with reproducibility checks on LUMI
             unsupported_dependency: ecmwf-ifs/field_api # We don't build Field API on LUMI for now
 

--- a/.github/workflows/build-hpc.yml
+++ b/.github/workflows/build-hpc.yml
@@ -100,6 +100,7 @@ jobs:
               #SBATCH --time=01:10:00
               #SBATCH --nodes=1
               #SBATCH --ntasks-per-node=8
+              #SBATCH --cpus-per-task=4
               #SBATCH --gpus-per-task=1
               #SBATCH --partition=standard-g
               #SBATCH --account={0}
@@ -221,7 +222,7 @@ jobs:
                     {% endif %}
                   {% endfor %}
                   {{ options['cmake_options']|join(' ') }}
-                cmake --build build
+                cmake --build build -j4
                 cmake --install build --prefix installation
                 popd
               {% endif %}
@@ -236,7 +237,7 @@ jobs:
                 {% endif %}
               {% endfor %}
               {{ cmake_options|join(' ') }}
-            cmake --build build
+            cmake --build build -j4
 
             ctest --test-dir build --output-on-failure {{ ctest_options }}
 

--- a/src/trans/gpu/CMakeLists.txt
+++ b/src/trans/gpu/CMakeLists.txt
@@ -110,11 +110,12 @@ function(generate_backend_sources)
 
   set(outfiles)
   foreach(file_i ${files})
-    get_filename_component(outfile_name    ${file_i} NAME)
     get_filename_component(outfile_name_we ${file_i} NAME_WE)
     get_filename_component(outfile_ext     ${file_i} EXT)
-    get_filename_component(outfile_dir     ${file_i} DIRECTORY)
-    set(outfile "${destination}/${file_i}")
+    # Note: we ensure the outfile has the precision suffix so that intermediate compilation files
+    # for single- and double-precision builds don't have the same name
+    # This is a known problem with crayftn
+    set(outfile "${destination}/${outfile_name_we}_${backend}${outfile_ext}")
     ecbuild_debug("Generate ${outfile}")
     generate_file(BACKEND ${backend} INPUT ${CMAKE_CURRENT_SOURCE_DIR}/${file_i} OUTPUT ${outfile})
     list(APPEND outfiles ${outfile})


### PR DESCRIPTION
crayftn generates "*.acc.o" intermediate files when compiling accelerated code. The intermediate file name is based on the input source file name and seems to be written into the same directory from where the compile command is invoked. This means that when building SP and DP libraries in parallel (normal when both are enabled and `make` is invoked with more than one thread), intermediates for SP and DP source files have the same name and clash. This causes a race condition.

This commit appends _sp or _dp to the source file name when it is put through the generator to ensure the intermediates don't clash.

Up until now (for three years...) we have always had to build the ecTrans backend in serial on LUMI without really understanding why. I have finally found the reason.

Of course I should submit a bug report to Cray, but we've no idea how long they will take to release a fix.