### PR TITLE
In transi, make trans_set_mpi_comm and trans_specnorm public

### DIFF
--- a/src/transi/transi_module.F90
+++ b/src/transi/transi_module.F90
@@ -83,6 +83,7 @@ public :: GathSpec_t
 public :: DistSpec_t
 public :: VorDivToUV_t
 public :: trans_use_mpi
+public :: trans_mpi_set_comm
 public :: trans_set_handles_limit
 public :: trans_set_radius
 public :: trans_set_leq_regions
@@ -90,6 +91,7 @@ public :: trans_set_nprtrv
 public :: trans_set_nprgpew
 public :: trans_init
 public :: trans_setup
+public :: trans_specnorm
 public :: trans_inquire
 public :: trans_dirtrans
 public :: trans_dirtrans_adj

--- a/src/transi/transi_module.F90
+++ b/src/transi/transi_module.F90
@@ -83,7 +83,7 @@ public :: GathSpec_t
 public :: DistSpec_t
 public :: VorDivToUV_t
 public :: trans_use_mpi
-public :: trans_mpi_set_comm
+public :: trans_set_mpi_comm
 public :: trans_set_handles_limit
 public :: trans_set_radius
 public :: trans_set_leq_regions


### PR DESCRIPTION
### Description
This pull request makes some small updates to the `trans_module` interface in `src/transi/transi_module.F90` by exposing additional procedures for external use.

 * Made `trans_set_mpi_comm` and `trans_specnorm` public, allowing other modules to access these procedures.

This supersedes #456 which has a compilation error.

### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf-ifs/ectrans/blob/develop/contributor_license_agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
